### PR TITLE
add story files for components/atoms

### DIFF
--- a/src/lib/components/atoms/Banner.story.svelte
+++ b/src/lib/components/atoms/Banner.story.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import '$lib/scss/global.scss';
+	import type { Hst as HstType } from '@histoire/plugin-svelte';
+	import Banner from './Banner.svelte';
+	import type { NoUndefinedField } from '$lib/utils/types';
+
+	export let Hst: HstType;
+
+	let props: NoUndefinedField<{
+		title?: string;
+	}> = {
+		title: 'Welcome to Our Service'
+	};
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/Banner" layout={{ type: 'grid', width: 400 }}>
+	<svelte:fragment slot="controls">
+		<svelte:component this={Hst.Text} bind:value={props.title} title="Banner Title" />
+	</svelte:fragment>
+
+	<div style="padding: 12px;">
+		<svelte:component this={Hst.Variant} title="Default Banner">
+			<Banner {...props} />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/atoms/Button.story.svelte
+++ b/src/lib/components/atoms/Button.story.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	import '$lib/scss/global.scss'; // Global styles
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Histoire type
+	import Button from './Button.svelte'; // Import the Button component
+	import Icon from '$lib/icons/chat.svelte'; // Example icon for demonstration
+	import type { NoUndefinedField } from '$lib/utils/types'; // Type utility
+
+	export let Hst: HstType; // Export Histoire instance
+
+	// Define properties for the Button with default values
+	let props: NoUndefinedField<{
+		color?: 'primary' | 'secondary';
+		style?: 'solid' | 'understated' | 'clear';
+		size?: 'small' | 'medium' | 'large';
+		href?: string;
+		additionalClass?: string;
+		target?: '_self' | '_blank';
+		rel?: string;
+	}> = {
+		color: 'primary',
+		style: 'solid',
+		size: 'medium',
+		href: 'string',
+		target: '_self',
+		rel: 'string',
+		additionalClass: ''
+	};
+
+	let text = 'Click Me'; // Default button text
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/Button" layout={{ type: 'grid', width: 400 }}>
+	<svelte:fragment slot="controls">
+		<svelte:component this={Hst.Text} bind:value={text} title="Button Text" />
+		<svelte:component
+			this={Hst.Select}
+			bind:value={props.color}
+			title="Color"
+			options={['primary', 'secondary']}
+		/>
+		<svelte:component
+			this={Hst.Select}
+			bind:value={props.style}
+			title="Style"
+			options={['solid', 'understated', 'clear']}
+		/>
+		<svelte:component
+			this={Hst.Select}
+			bind:value={props.size}
+			title="Size"
+			options={['small', 'medium', 'large']}
+		/>
+		<svelte:component this={Hst.Text} bind:value={props.href} title="Href (optional)" />
+		<svelte:component
+			this={Hst.Select}
+			bind:value={props.target}
+			title="Target"
+			options={['_self', '_blank']}
+		/>
+		<svelte:component this={Hst.Text} bind:value={props.rel} title="Rel (optional)" />
+		<svelte:component this={Hst.Text} bind:value={props.additionalClass} title="Additional Class" />
+	</svelte:fragment>
+
+	<div style="padding: 12px;">
+		<svelte:component this={Hst.Variant} title="Button Without Icon">
+			<Button {...props}>
+				{text}
+			</Button>
+		</svelte:component>
+		<svelte:component this={Hst.Variant} title="Button With Icon">
+			<Button {...props}>
+				<Icon slot="icon" />
+				{text}
+			</Button>
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/atoms/Card.story.svelte
+++ b/src/lib/components/atoms/Card.story.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import '$lib/scss/global.scss'; // Import global styles
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Histoire type
+	import Card from './Card.svelte'; // Import the Card component
+	import type { NoUndefinedField } from '$lib/utils/types'; // Type utility
+
+	export let Hst: HstType; // Export Histoire instance
+
+	// Define properties for the Card with default values
+	let props: NoUndefinedField<{
+		title: {
+			icon: string; // HTML string for the icon
+			title: string; // Title of the card
+			para: string; // Paragraph text
+		};
+	}> = {
+		title: {
+			icon: '<svg width="24" height="24" fill="currentColor"><circle cx="12" cy="12" r="10"/></svg>', // Example icon (a circle)
+			title: 'Card Title',
+			para: 'This is a description of the card content.'
+		}
+	};
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/Card" layout={{ type: 'grid', width: 400 }}>
+	<svelte:fragment slot="controls">
+		<svelte:component this={Hst.Text} bind:value={props.title.icon} title="Icon (HTML)" />
+		<svelte:component this={Hst.Text} bind:value={props.title.title} title="Card Title" />
+		<svelte:component this={Hst.Text} bind:value={props.title.para} title="Paragraph" />
+	</svelte:fragment>
+
+	<div style="padding: 12px;">
+		<svelte:component this={Hst.Variant} title="Default Card">
+			<Card title={props.title} />
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/atoms/Cards.story.svelte
+++ b/src/lib/components/atoms/Cards.story.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import '$lib/scss/global.scss'; // Import global styles
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import Histoire type
+	import Cards from './Cards.svelte'; // Import the Cards component
+
+	export let Hst: HstType; // Export Histoire instance
+
+	// Define the props for the card component
+	let props = {
+		additionalClass: '',
+		href: '',
+		content: 'This is a card content.'
+	};
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/Cards" layout={{ type: 'grid', width: 400 }}>
+	<svelte:fragment slot="controls">
+		<svelte:component this={Hst.Text} bind:value={props.additionalClass} title="Additional Class" />
+		<svelte:component this={Hst.Text} bind:value={props.href} title="Link (Href)" />
+		<svelte:component this={Hst.Text} bind:value={props.content} title="Card Content" />
+	</svelte:fragment>
+
+	<div style="padding: 12px;">
+		<svelte:component this={Hst.Variant} title="Default Card">
+			<Cards {...props}>
+				<div slot="content">{props.content}</div>
+			</Cards>
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/atoms/GitRepo.story.svelte
+++ b/src/lib/components/atoms/GitRepo.story.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import the Histoire types
+	export let Hst: HstType; // This will be provided by Histoire
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/GitRepo" layout={{ type: 'grid', width: 600 }}>
+	<div style="padding: 12px; text-align: center;">
+		<svelte:component this={Hst.Variant} title="Default Variant">
+			<div>
+				<svg xmlns="http://www.w3.org/2000/svg" height="15pt" viewBox="0 0 92 92">
+					<defs>
+						<clipPath id="a">
+							<path d="M0 .113h91.887V92H0Zm0 0" />
+						</clipPath>
+					</defs>
+					<g clip-path="url(#a)">
+						<path
+							style="stroke:none;fill-rule:nonzero;fill:#fff;fill-opacity:1"
+							d="M90.156 41.965 50.036 1.848a5.918 5.918 0 0 0-8.372 0l-8.328 8.332 10.566 10.566a7.03 7.03 0 0 1 7.23 1.684 7.034 7.034 0 0 1 1.669 7.277l10.187 10.184a7.028 7.028 0 0 1 7.278 1.672 7.04 7.04 0 0 1 0 9.957 7.05 7.05 0 0 1-9.965 0 7.044 7.044 0 0 1-1.528-7.66l-9.5-9.497V59.36a7.04 7.04 0 0 1 1.86 11.29 7.04 7.04 0 0 1-9.957 0 7.04 7.04 0 0 1 0-9.958 7.06 7.06 0 0 1 2.304-1.539V33.926a7.049 7.049 0 0 1-3.82-9.234L29.242 14.272 1.73 41.777a5.925 5.925 0 0 0 0 8.371L41.852 90.27a5.925 5.925 0 0 0 8.37 0l39.934-39.934a5.925 5.925 0 0 0 0-8.371"
+						/>
+					</g>
+				</svg>
+			</div>
+		</svelte:component>
+	</div>
+</svelte:component>

--- a/src/lib/components/atoms/HeroCard.story.svelte
+++ b/src/lib/components/atoms/HeroCard.story.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Hst as HstType } from '@histoire/plugin-svelte'; // Import the Histoire types
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import the Histoire types
 	import HeroCard from './HeroCard.svelte'; // Import the HeroCard component
 
 	export let Hst: HstType; // This will be provided by Histoire

--- a/src/lib/components/atoms/HeroCard.story.svelte
+++ b/src/lib/components/atoms/HeroCard.story.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Hst as HstType } from '@histoire/plugin-svelte'; // Import the Histoire types
+	import HeroCard from './HeroCard.svelte'; // Import the HeroCard component
+
+	export let Hst: HstType; // This will be provided by Histoire
+
+	// Sample data for the HeroCard
+	const title = 'My Awesome Project';
+	const details =
+		'This project is designed to help you achieve great things. It offers a variety of features and benefits.';
+	const version = 'https://github.com/your-repo/releases/tag/v3.0.0'; // Replace with your actual version link
+	const liveDemo = 'https://your-live-demo-link.com'; // Replace with your actual live demo link
+	const learnMore = 'https://your-learn-more-link.com'; // Replace with your actual learn more link
+</script>
+
+<svelte:component this={Hst.Story} title="Molecules/HeroCard" layout={{ type: 'grid', width: 600 }}>
+	<svelte:component this={Hst.Variant} title="Default Variant">
+		<HeroCard {title} {details} {version} {liveDemo} {learnMore} />
+	</svelte:component>
+</svelte:component>

--- a/src/lib/components/atoms/Image.story.svelte
+++ b/src/lib/components/atoms/Image.story.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import the Histoire types
+	import Image from './Image.svelte'; // Import the Image component
+
+	export let Hst: HstType; // This will be provided by Histoire
+
+	// Sample data for the Image component
+	const src = 'https://via.placeholder.com/800'; // Replace with an actual image URL
+	const alt = 'Placeholder Image';
+	const fullBleed = true; // Set to true or false based on your requirement
+	const widths = ['320', '480', '800']; // Sample widths for responsive images
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/Image" layout={{ type: 'grid', width: 600 }}>
+	<svelte:component this={Hst.Variant} title="Default Variant">
+		<Image {src} {alt} {fullBleed} {widths} />
+	</svelte:component>
+
+	<svelte:component this={Hst.Variant} title="Without Full Bleed">
+		<Image {src} {alt} fullBleed={false} {widths} />
+	</svelte:component>
+</svelte:component>

--- a/src/lib/components/atoms/RelatedCard.story.svelte
+++ b/src/lib/components/atoms/RelatedCard.story.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import the Histoire types
+	import RelatedCard from './RelatedCard.svelte'; // Import the RelatedCard component
+
+	export let Hst: HstType; // This will be provided by Histoire
+
+	// Sample data for the RelatedCard component
+	const title = 'Learn Svelte';
+	const details = 'Discover the power of Svelte, a modern JavaScript framework.';
+	const version = 'https://svelte.dev/release';
+	const liveDemo = 'https://svelte.dev/repl';
+	const learnMore = 'https://svelte.dev/docs';
+	const additionalClass = 'custom-class'; // Optional additional class
+</script>
+
+<svelte:component
+	this={Hst.Story}
+	title="Molecules/RelatedCard"
+	layout={{ type: 'grid', width: 600 }}
+>
+	<svelte:component this={Hst.Variant} title="Default Variant">
+		<RelatedCard {additionalClass} href={liveDemo} on:click={() => console.log('Card clicked!')}>
+			<div slot="content">
+				<h3>{title}</h3>
+				<p>{details}</p>
+			</div>
+			<div slot="footer">
+				<a href={version} target="_blank" class="version">Version</a>
+				<a href={liveDemo} class="live-demo">Live Demo</a>
+				<a href={learnMore} class="learn-btn">Learn More</a>
+			</div>
+		</RelatedCard>
+	</svelte:component>
+
+	<svelte:component this={Hst.Variant} title="Custom Class Variant">
+		<RelatedCard additionalClass="my-custom-class" href={liveDemo}>
+			<div slot="content">
+				<h3>Custom Styled Card</h3>
+				<p>This card has a custom style applied.</p>
+			</div>
+			<div slot="footer">
+				<a href={version} target="_blank" class="version">Version</a>
+				<a href={liveDemo} class="live-demo">Live Demo</a>
+				<a href={learnMore} class="learn-btn">Learn More</a>
+			</div>
+		</RelatedCard>
+	</svelte:component>
+</svelte:component>

--- a/src/lib/components/atoms/Slider.story.svelte
+++ b/src/lib/components/atoms/Slider.story.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import the Histoire types
+	import Slider from './Slider.svelte'; // Import the Slider component
+
+	export let Hst: HstType; // This will be provided by Histoire
+
+	// Sample data for the Slider component
+	const titleArr = [
+		{ title: 'Learn Svelte', link: 'https://svelte.dev/docs' },
+		{ title: 'Explore React', link: 'https://reactjs.org/docs/getting-started.html' },
+		{ title: 'Dive into Vue', link: 'https://vuejs.org/v2/guide/' },
+		{ title: 'Angular Documentation', link: 'https://angular.io/docs' },
+		{ title: 'Next.js Guide', link: 'https://nextjs.org/docs/getting-started' },
+		{ title: 'Back to Home', link: '' } // Example of a non-link item
+	];
+</script>
+
+<svelte:component this={Hst.Story} title="Molecules/Slider" layout={{ type: 'grid', width: 600 }}>
+	<svelte:component this={Hst.Variant} title="Default Slider">
+		<Slider {titleArr} />
+	</svelte:component>
+
+	<svelte:component this={Hst.Variant} title="Slider with No Links">
+		<Slider
+			titleArr={[
+				{ title: 'Static Item 1', link: '' },
+				{ title: 'Static Item 2', link: '' },
+				{ title: 'Static Item 3', link: '' }
+			]}
+		/>
+	</svelte:component>
+</svelte:component>

--- a/src/lib/components/atoms/Table.story.svelte
+++ b/src/lib/components/atoms/Table.story.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import the Histoire types
+	import Table from './Table.svelte'; // Import the Table component
+
+	export let Hst: HstType; // This will be provided by Histoire
+
+	// Sample table headings
+	const tableHeading = [
+		{ fieldName: 'name', displayName: 'Project Name' },
+		{ fieldName: 'repo', displayName: 'Repository' },
+		{ fieldName: 'site', displayName: 'Website' },
+		{ fieldName: 'demo', displayName: 'Demo' },
+		{ fieldName: 'useCase', displayName: 'Use Case' }
+	];
+
+	// Sample table data
+	const tableData = [
+		{
+			name: 'Project A',
+			repo: 'https://github.com/example/project-a',
+			site: 'https://example.com/a',
+			demo: 'https://example.com/demo/a',
+			useCase: 'Example use case description A'
+		},
+		{
+			name: 'Project B',
+			repo: 'https://github.com/example/project-b',
+			site: '',
+			demo: 'https://example.com/demo/b',
+			useCase: 'Example use case description B'
+		},
+		{
+			name: 'Project C',
+			repo: 'https://github.com/example/project-c',
+			site: 'https://example.com/c',
+			demo: '',
+			useCase: 'Example use case description C'
+		}
+	];
+</script>
+
+<svelte:component this={Hst.Story} title="Molecules/Table" layout={{ type: 'grid', width: 600 }}>
+	<svelte:component this={Hst.Variant} title="Default Table">
+		<Table {tableHeading} {tableData} />
+	</svelte:component>
+</svelte:component>

--- a/src/lib/components/atoms/TableOfContents.story.svelte
+++ b/src/lib/components/atoms/TableOfContents.story.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import Histoire types
+	import TableOfContents from './TableOfContents.svelte'; // Import the TableOfContents component
+
+	export let Hst: HstType; // Provided by Histoire
+
+	// Sample sections with subsections
+	const sections = [
+		{
+			name: 'Introduction',
+			id: 'introduction',
+			subsections: [
+				{ name: 'What is Svelte?', id: 'what-is-svelte' },
+				{ name: 'Getting Started', id: 'getting-started' }
+			]
+		},
+		{
+			name: 'Components',
+			id: 'components',
+			subsections: [
+				{ name: 'Creating Components', id: 'creating-components' },
+				{ name: 'Component Props', id: 'component-props' }
+			]
+		},
+		{
+			name: 'Stores',
+			id: 'stores',
+			subsections: []
+		},
+		{
+			name: 'Routing',
+			id: 'routing',
+			subsections: [
+				{ name: 'Using SvelteKit', id: 'using-sveltekit' },
+				{ name: 'Creating Routes', id: 'creating-routes' }
+			]
+		},
+		{
+			name: 'Deployment',
+			id: 'deployment',
+			subsections: []
+		}
+	];
+</script>
+
+<svelte:component
+	this={Hst.Story}
+	title="Molecules/TableOfContents"
+	layout={{ type: 'grid', width: 600 }}
+>
+	<svelte:component this={Hst.Variant} title="Default Table of Contents">
+		<TableOfContents {sections} />
+	</svelte:component>
+</svelte:component>

--- a/src/lib/components/atoms/Tag.story.svelte
+++ b/src/lib/components/atoms/Tag.story.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import Histoire types
+	import Tag from './Tag.svelte'; // Import the Tag component
+
+	export let Hst: HstType; // Provided by Histoire
+
+	// Define the internalTag with strict color types
+	const internalTag = {
+		tag: 'Internal Link',
+		href: '/tags/internal',
+		color: 'primary' as 'primary' | 'secondary' // Ensure type safety
+	};
+
+	const externalTag = {
+		tag: 'External Link',
+		href: 'https://www.example.com',
+		color: 'secondary' as 'primary' | 'secondary' // Ensure type safety
+	};
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/Tag" layout={{ type: 'grid', width: 600 }}>
+	<svelte:component this={Hst.Variant} title="Internal Tag">
+		<Tag href={internalTag.href} tag={internalTag.tag} color={internalTag.color}>Internal Tag</Tag>
+	</svelte:component>
+
+	<svelte:component this={Hst.Variant} title="External Tag">
+		<Tag href={externalTag.href} tag={externalTag.tag} color={externalTag.color}>External Tag</Tag>
+	</svelte:component>
+</svelte:component>

--- a/src/lib/components/atoms/Tag.svelte
+++ b/src/lib/components/atoms/Tag.svelte
@@ -6,6 +6,7 @@
 
 	export let href: string | undefined = undefined;
 	export let tag: string;
+
 	const isExternalLink = !!href && HttpRegex.test(href);
 	export let target: '_self' | '_blank' = isExternalLink ? '_blank' : '_self';
 	export let rel = isExternalLink ? 'noopener noreferrer' : undefined;

--- a/src/lib/components/atoms/TagCard.story.svelte
+++ b/src/lib/components/atoms/TagCard.story.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import TagCard from './TagCard.svelte'; // Import the TagCard component
+	import type { Hst as HstType } from '@histoire/plugin-svelte'; // Import Histoire types
+
+	export let Hst: HstType; // Provided by Histoire
+
+	const internalCard = {
+		title: 'Internal Card',
+		content: 'This card links to another part of the site.',
+		footer: 'More info',
+		href: '/internal',
+		image: 'https://via.placeholder.com/300', // Example image URL
+		color: 'primary' // Define a color if needed
+	};
+
+	const externalCard = {
+		title: 'External Card',
+		content: 'This card links to an external website.',
+		footer: 'Visit Now',
+		href: 'https://www.example.com',
+		image: 'https://via.placeholder.com/300', // Example image URL
+		color: 'secondary' // Define a color if needed
+	};
+</script>
+
+<svelte:component this={Hst.Story} title="Atoms/TagCard" layout={{ type: 'grid', width: 600 }}>
+	<svelte:component this={Hst.Variant} title="Internal Tag Card">
+		<TagCard href={internalCard.href} additionalClass={internalCard.color}>
+			<img
+				slot="image"
+				src={internalCard.image}
+				alt="Illustration related to internal navigation"
+			/>
+			<div slot="content">
+				<h3>{internalCard.title}</h3>
+				<p>{internalCard.content}</p>
+			</div>
+			<div slot="footer">{internalCard.footer}</div>
+		</TagCard>
+	</svelte:component>
+
+	<svelte:component this={Hst.Variant} title="External Tag Card">
+		<TagCard href={externalCard.href} additionalClass={externalCard.color}>
+			<img slot="image" src={externalCard.image} alt="Graphic representing external link" />
+			<div slot="content">
+				<h3>{externalCard.title}</h3>
+				<p>{externalCard.content}</p>
+			</div>
+			<div slot="footer">{externalCard.footer}</div>
+		</TagCard>
+	</svelte:component>
+</svelte:component>


### PR DESCRIPTION
In `components/atoms`, add story to each component, per issue [Storybook does not work in the new version #83](https://github.com/torrust/torrust-website/issues/83)

Todo: `components/molecules` and `components/organisms`