### PR TITLE
order articles in homepage by latest

### DIFF
--- a/src/routes/(home)/+page.server.ts
+++ b/src/routes/(home)/+page.server.ts
@@ -3,7 +3,10 @@ import { fetchMarkdownPosts } from '$lib/utils/index_posts';
 
 export async function load() {
 	const allPosts = await fetchMarkdownPosts();
-	const posts = allPosts.slice(0, 6);
+
+	const posts = allPosts
+		.sort((a, b) => new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime())
+		.slice(0, 6);
 
 	return {
 		features,

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -56,7 +56,9 @@
 			<h2>Related Posts:</h2>
 			<div class="grid">
 				{#each data.posts.slice(0, 3) as post}
-					<BlogPreview post_data={post.meta} />
+					<a href={post.path}>
+						<BlogPreview post_data={post.meta} />
+					</a>
 				{/each}
 			</div>
 		</div>


### PR DESCRIPTION
* [Latest articles in homepage are not ordered #105](https://github.com/torrust/torrust-website/issues/105),
* Fix links to articles in `Related Posts` under each blog post.