### PR TITLE
add melt-ui toc in (pages)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,11 @@
 			"dependencies": {
 				"@fontsource-variable/roboto-mono": "^5.0.19",
 				"@fontsource-variable/roboto-slab": "^5.0.20",
+				"@tailwindcss/typography": "^0.5.15",
+				"autoprefixer": "^10.4.20",
 				"feather-icons": "^4.29.2",
 				"flexsearch": "^0.7.43",
+				"postcss": "^8.4.49",
 				"shiki": "^1.6.1",
 				"shiki-es": "^0.14.0",
 				"svelte-toc": "^0.5.9",
@@ -22,6 +25,8 @@
 			"devDependencies": {
 				"@histoire/plugin-svelte": "^0.17.17",
 				"@iconify/svelte": "^4.0.2",
+				"@melt-ui/pp": "^0.3.2",
+				"@melt-ui/svelte": "^0.86.0",
 				"@sveltejs/adapter-static": "^3.0.1",
 				"@sveltejs/kit": "^2.5.25",
 				"@types/swiper": "^5.4.3",
@@ -46,6 +51,7 @@
 				"svelte": "^4.2.19",
 				"svelte-check": "^3.8.0",
 				"svelte-sitemap": "^2.6.0",
+				"tailwindcss": "^3.4.14",
 				"typescript": "^5.5.4",
 				"vite": "^5.2.12"
 			}
@@ -58,6 +64,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@alloc/quick-lru": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+			"integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -631,6 +649,34 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.6.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+			"integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.8"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.6.12",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+			"integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.8"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+			"integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@fontsource-variable/roboto-mono": {
 			"version": "5.0.19",
 			"resolved": "https://registry.npmjs.org/@fontsource-variable/roboto-mono/-/roboto-mono-5.0.19.tgz",
@@ -821,6 +867,60 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@internationalized/date": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.6.tgz",
+			"integrity": "sha512-jLxQjefH9VI5P9UQuqB6qNKnvFt1Ky1TPIzHGsIlCi7sZZoMR8SdYbBGRvM0y+Jtb+ez4ieBzmiAUcpmPYpyOw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@swc/helpers": "^0.5.0"
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -908,11 +1008,62 @@
 				"@lezer/common": "^1.0.0"
 			}
 		},
+		"node_modules/@melt-ui/pp": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@melt-ui/pp/-/pp-0.3.2.tgz",
+			"integrity": "sha512-xKkPvaIAFinklLXcQOpwZ8YSpqAFxykjWf8Y/fSJQwsixV/0rcFs07hJ49hJjPy5vItvw5Qa0uOjzFUbXzBypQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.5"
+			},
+			"peerDependencies": {
+				"@melt-ui/svelte": ">= 0.29.0",
+				"svelte": "^3.55.0 || ^4.0.0 || ^5.0.0-next.1"
+			}
+		},
+		"node_modules/@melt-ui/svelte": {
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@melt-ui/svelte/-/svelte-0.86.0.tgz",
+			"integrity": "sha512-kFyioxwvDZfD7nChq+sHaJKyLQPleJlzIORNJx1Ou1NavMrwK1sJkAdtgxuyEzief7SU3f4skSF0Cpvjewx5fA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.3.1",
+				"@floating-ui/dom": "^1.4.5",
+				"@internationalized/date": "^3.5.0",
+				"dequal": "^2.0.3",
+				"focus-trap": "^7.5.2",
+				"nanoid": "^5.0.4"
+			},
+			"peerDependencies": {
+				"svelte": "^3.0.0 || ^4.0.0 || ^5.0.0-next.118"
+			}
+		},
+		"node_modules/@melt-ui/svelte/node_modules/nanoid": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.8.tgz",
+			"integrity": "sha512-TcJPw+9RV9dibz1hHUzlLVy8N4X9TnwirAjrU08Juo6BNKggzVfP2ZJ/3ZUSq15Xl5i85i+Z89XBO90pB2PghQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.js"
+			},
+			"engines": {
+				"node": "^18 || >=20"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -926,7 +1077,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -936,7 +1086,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -996,6 +1145,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -1319,6 +1478,44 @@
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
 				"vite": "^5.0.0"
+			}
+		},
+		"node_modules/@swc/helpers": {
+			"version": "0.5.15",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+			"integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.8.0"
+			}
+		},
+		"node_modules/@tailwindcss/typography": {
+			"version": "0.5.15",
+			"resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.15.tgz",
+			"integrity": "sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==",
+			"license": "MIT",
+			"dependencies": {
+				"lodash.castarray": "^4.4.0",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.merge": "^4.6.2",
+				"postcss-selector-parser": "6.0.10"
+			},
+			"peerDependencies": {
+				"tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20"
+			}
+		},
+		"node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+			"integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@tootallnate/once": {
@@ -1743,7 +1940,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -1753,7 +1949,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -1765,11 +1960,16 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"license": "MIT"
+		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
 			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
@@ -1778,6 +1978,12 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/arg": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+			"license": "MIT"
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -1829,6 +2035,43 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/autoprefixer": {
+			"version": "10.4.20",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+			"integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/autoprefixer"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"caniuse-lite": "^1.0.30001646",
+				"fraction.js": "^4.3.7",
+				"normalize-range": "^0.1.2",
+				"picocolors": "^1.0.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"bin": {
+				"autoprefixer": "bin/autoprefixer"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
@@ -1860,7 +2103,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/bare-events": {
@@ -1939,7 +2181,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
 			"integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -1974,7 +2215,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -1984,13 +2224,44 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/browserslist": {
+			"version": "4.24.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
+			"integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"caniuse-lite": "^1.0.30001669",
+				"electron-to-chromium": "^1.5.41",
+				"node-releases": "^2.0.18",
+				"update-browserslist-db": "^1.1.1"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
 			}
 		},
 		"node_modules/buffer": {
@@ -2059,6 +2330,35 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/camelcase-css": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001680",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
+			"integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "CC-BY-4.0"
+		},
 		"node_modules/capital-case": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
@@ -2113,7 +2413,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
 			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.2",
@@ -2178,7 +2477,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -2191,7 +2489,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/color-string": {
@@ -2326,7 +2623,6 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -2354,7 +2650,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
@@ -2558,6 +2853,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/didyoumean": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+			"integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2570,6 +2871,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/dlv": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+			"license": "MIT"
 		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
@@ -2609,6 +2916,12 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"license": "MIT"
+		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2616,11 +2929,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.56",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.56.tgz",
+			"integrity": "sha512-7lXb9dAvimCFdvUMTyucD4mnIndt/xhRKFAlky0CyFogdnNmdPQNoHI23msF/2V4mpTxMzgMdjK4+YRlFlRQZw==",
+			"license": "ISC"
+		},
 		"node_modules/email-addresses": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
 			"integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"license": "MIT"
 		},
 		"node_modules/encodeurl": {
@@ -2697,6 +3022,15 @@
 				"@esbuild/win32-arm64": "0.21.5",
 				"@esbuild/win32-ia32": "0.21.5",
 				"@esbuild/win32-x64": "0.21.5"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/escape-html": {
@@ -3081,7 +3415,6 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
 			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -3112,7 +3445,6 @@
 			"version": "1.17.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
 			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -3173,7 +3505,6 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -3281,6 +3612,32 @@
 			"integrity": "sha512-c5o/+Um8aqCSOXGcZoqZOm+NqtVwNsvVpWv6lfmSclU954O3wvQKxxK8zj74fPaSJbXpSLTs4PRhh+wnoCXnKg==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/focus-trap": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.1.tgz",
+			"integrity": "sha512-nB8y4nQl8PshahLpGKZOq1sb0xrMVFSn6at7u/qOsBZTlZRzaapISGENcB6mOkoezbClZyiMwEF/dGY8AZ00rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tabbable": "^6.2.0"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -3294,6 +3651,19 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/fraction.js": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+			"integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"type": "patreon",
+				"url": "https://github.com/sponsors/rawify"
 			}
 		},
 		"node_modules/fs-constants": {
@@ -3329,7 +3699,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -3338,6 +3707,15 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/gh-pages": {
@@ -3433,7 +3811,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -3578,6 +3955,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/hast-util-heading-rank": {
@@ -3916,13 +4305,27 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
 			"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"binary-extensions": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+			"integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-extendable": {
@@ -3939,17 +4342,24 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -3962,7 +4372,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -4011,14 +4420,27 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
 		},
 		"node_modules/jiti": {
 			"version": "1.21.0",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
 			"integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "bin/jiti.js"
@@ -4183,11 +4605,16 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
 			"integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"license": "MIT"
 		},
 		"node_modules/linkify-it": {
 			"version": "3.0.3",
@@ -4221,11 +4648,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash.castarray": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+			"integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"license": "MIT"
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lower-case": {
@@ -4237,6 +4675,12 @@
 			"dependencies": {
 				"tslib": "^2.0.3"
 			}
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"license": "ISC"
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.10",
@@ -4354,7 +4798,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -4364,7 +4807,6 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -4424,7 +4866,6 @@
 			"version": "9.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
 			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -4444,6 +4885,15 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/mkdirp": {
@@ -4506,11 +4956,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.7",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
 			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4570,11 +5030,25 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/node-releases": {
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+			"integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+			"license": "MIT"
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/normalize-range": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4591,10 +5065,18 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-hash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+			"integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/on-finished": {
@@ -4679,6 +5161,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -4786,10 +5274,31 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"license": "MIT"
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/path-type": {
@@ -4821,17 +5330,15 @@
 			}
 		},
 		"node_modules/picocolors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-			"dev": true,
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -4844,7 +5351,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4871,6 +5377,15 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pirates": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+			"integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/pkg-dir": {
@@ -4955,10 +5470,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.47",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-			"integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
-			"dev": true,
+			"version": "8.4.49",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+			"integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4976,11 +5490,47 @@
 			"license": "MIT",
 			"dependencies": {
 				"nanoid": "^3.3.7",
-				"picocolors": "^1.1.0",
+				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/postcss-import": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+			"integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+			"license": "MIT",
+			"dependencies": {
+				"postcss-value-parser": "^4.0.0",
+				"read-cache": "^1.0.0",
+				"resolve": "^1.1.7"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
+		"node_modules/postcss-js": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+			"integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+			"license": "MIT",
+			"dependencies": {
+				"camelcase-css": "^2.0.1"
+			},
+			"engines": {
+				"node": "^12 || ^14 || >= 16"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.21"
 			}
 		},
 		"node_modules/postcss-load-config": {
@@ -5011,6 +5561,31 @@
 				"ts-node": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/postcss-nested": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+			"integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"postcss-selector-parser": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=12.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.14"
 			}
 		},
 		"node_modules/postcss-safe-parser": {
@@ -5058,10 +5633,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
-			"integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
-			"dev": true,
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -5070,6 +5644,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"license": "MIT"
 		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.2",
@@ -5221,7 +5801,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5271,6 +5850,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/read-cache": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+			"license": "MIT",
+			"dependencies": {
+				"pify": "^2.3.0"
+			}
+		},
 		"node_modules/readable-stream": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -5290,7 +5878,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
 			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^2.2.1"
@@ -5369,6 +5956,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/resolve": {
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.13.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5383,7 +5987,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
@@ -5447,7 +6050,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5640,7 +6242,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -5653,7 +6254,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5684,6 +6284,18 @@
 			"integrity": "sha512-e+/aueHx0YeIEut6RXC6K8gSf0PykwZiHD7q7AHtpTW8Kd8TpFUIWqTwhAnrGjOyOMyrwv+syr5WPagMpDpVYQ==",
 			"deprecated": "Please migrate to https://github.com/antfu/shikiji",
 			"license": "MIT"
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/simple-concat": {
 			"version": "1.0.1",
@@ -5869,11 +6481,88 @@
 				"safe-buffer": "~5.2.0"
 			}
 		},
+		"node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -5955,6 +6644,57 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/sucrase": {
+			"version": "3.35.0",
+			"resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+			"integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"commander": "^4.0.0",
+				"glob": "^10.3.10",
+				"lines-and-columns": "^1.1.6",
+				"mz": "^2.7.0",
+				"pirates": "^4.0.1",
+				"ts-interface-checker": "^0.1.9"
+			},
+			"bin": {
+				"sucrase": "bin/sucrase",
+				"sucrase-node": "bin/sucrase-node"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/sucrase/node_modules/commander": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/sucrase/node_modules/glob": {
+			"version": "10.4.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+			"integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5966,6 +6706,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/svelte": {
@@ -6155,6 +6907,121 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tabbable": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+			"integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tailwindcss": {
+			"version": "3.4.14",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.14.tgz",
+			"integrity": "sha512-IcSvOcTRcUtQQ7ILQL5quRDg7Xs93PdJEk1ZLbhhvJc7uj/OAhYOnruEiwnGgBvUtaUAJ8/mhSw1o8L2jCiENA==",
+			"license": "MIT",
+			"dependencies": {
+				"@alloc/quick-lru": "^5.2.0",
+				"arg": "^5.0.2",
+				"chokidar": "^3.5.3",
+				"didyoumean": "^1.2.2",
+				"dlv": "^1.1.3",
+				"fast-glob": "^3.3.0",
+				"glob-parent": "^6.0.2",
+				"is-glob": "^4.0.3",
+				"jiti": "^1.21.0",
+				"lilconfig": "^2.1.0",
+				"micromatch": "^4.0.5",
+				"normalize-path": "^3.0.0",
+				"object-hash": "^3.0.0",
+				"picocolors": "^1.0.0",
+				"postcss": "^8.4.23",
+				"postcss-import": "^15.1.0",
+				"postcss-js": "^4.0.1",
+				"postcss-load-config": "^4.0.1",
+				"postcss-nested": "^6.0.1",
+				"postcss-selector-parser": "^6.0.11",
+				"resolve": "^1.22.2",
+				"sucrase": "^3.32.0"
+			},
+			"bin": {
+				"tailwind": "lib/cli.js",
+				"tailwindcss": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/postcss-load-config": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+			"integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"lilconfig": "^3.0.0",
+				"yaml": "^2.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"postcss": ">=8.0.9",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"postcss": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tailwindcss/node_modules/postcss-load-config/node_modules/lilconfig": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+			"integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antonk52"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/yaml": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
+			"integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/tar-fs": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
@@ -6189,6 +7056,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"license": "MIT",
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"license": "MIT",
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/tiny-glob": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
@@ -6204,7 +7092,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -6315,10 +7202,16 @@
 				"typescript": ">=4.2.0"
 			}
 		},
+		"node_modules/ts-interface-checker": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/tslib": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
 			"license": "0BSD"
 		},
@@ -6530,6 +7423,36 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+			"integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.0"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
 		"node_modules/upper-case": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
@@ -6575,7 +7498,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/utils-merge": {
@@ -6838,7 +7760,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -6858,6 +7779,100 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
 	"devDependencies": {
 		"@histoire/plugin-svelte": "^0.17.17",
 		"@iconify/svelte": "^4.0.2",
+		"@melt-ui/pp": "^0.3.2",
+		"@melt-ui/svelte": "^0.86.0",
 		"@sveltejs/adapter-static": "^3.0.1",
 		"@sveltejs/kit": "^2.5.25",
 		"@types/swiper": "^5.4.3",
@@ -44,6 +46,7 @@
 		"svelte": "^4.2.19",
 		"svelte-check": "^3.8.0",
 		"svelte-sitemap": "^2.6.0",
+		"tailwindcss": "^3.4.14",
 		"typescript": "^5.5.4",
 		"vite": "^5.2.12"
 	},
@@ -51,8 +54,11 @@
 	"dependencies": {
 		"@fontsource-variable/roboto-mono": "^5.0.19",
 		"@fontsource-variable/roboto-slab": "^5.0.20",
+		"@tailwindcss/typography": "^0.5.15",
+		"autoprefixer": "^10.4.20",
 		"feather-icons": "^4.29.2",
 		"flexsearch": "^0.7.43",
+		"postcss": "^8.4.49",
 		"shiki": "^1.6.1",
 		"shiki-es": "^0.14.0",
 		"svelte-toc": "^0.5.9",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+	plugins: {
+		tailwindcss: {},
+		autoprefixer: {}
+	}
+};

--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,7 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
+/* src/app.css */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/lib/components/atoms/Banner.svelte
+++ b/src/lib/components/atoms/Banner.svelte
@@ -29,4 +29,9 @@
 		display: flex;
 		text-align: center;
 	}
+
+	h1 {
+		font-size: 2.5rem;
+		font-weight: bolder;
+	}
 </style>

--- a/src/lib/components/atoms/Card.svelte
+++ b/src/lib/components/atoms/Card.svelte
@@ -8,7 +8,7 @@
 		{@html title.icon}
 	</span>
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-	<h2>{@html title.title}</h2>
+	<h3>{@html title.title}</h3>
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 	<p>{@html title.para}</p>
 </div>
@@ -26,9 +26,10 @@
 			display: inline-block;
 		}
 
-		h2 {
+		h3 {
 			font-size: 20px;
 			color: rgba(245, 245, 245, 0.96);
+			font-weight: bold;
 		}
 
 		p {

--- a/src/lib/components/atoms/PagesWrapper.svelte
+++ b/src/lib/components/atoms/PagesWrapper.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	export let heading: string;
+</script>
+
+<div class="para">
+	{#if heading}
+		<h1>{heading}</h1>
+	{/if}
+	<div class="layout">
+		<slot />
+	</div>
+</div>
+
+<style lang="scss">
+	@import '$lib/scss/breakpoints.scss';
+
+	.para {
+		display: flex;
+		flex-direction: column;
+		max-width: 1100px;
+		margin: 0 auto;
+	}
+
+	h1 {
+		padding-inline: 2.5rem;
+		font-size: 2rem;
+		padding-top: 6rem;
+	}
+
+	.layout {
+		display: flex;
+		flex-direction: column;
+		padding-top: 4rem;
+		padding-inline: 2.5rem;
+	}
+
+	@include for-desktop-up {
+		.layout {
+			height: 100vh;
+			flex-direction: row;
+			gap: 4rem;
+		}
+	}
+</style>

--- a/src/lib/components/atoms/TableOfContents.svelte
+++ b/src/lib/components/atoms/TableOfContents.svelte
@@ -23,7 +23,7 @@
 					}
 				});
 			},
-			{ threshold: 0.9 }
+			{ threshold: 0.1 }
 		);
 
 		sections.forEach((section) => {

--- a/src/lib/components/atoms/Toc.svelte
+++ b/src/lib/components/atoms/Toc.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { onMount } from 'svelte'; // ✨ Import Svelte onMount
+	import Tree from './Tree.svelte';
+	import { createTableOfContents } from '@melt-ui/svelte';
+	import { pushState } from '$app/navigation';
+
+	let isMobileScreen = false;
+
+	onMount(() => {
+		isMobileScreen = window.innerWidth <= 1200;
+
+		const handleResize = () => {
+			isMobileScreen = window.innerWidth <= 1024;
+		};
+		window.addEventListener('resize', handleResize);
+		return () => window.removeEventListener('resize', handleResize); // ✨ Clean up
+	});
+
+	const {
+		elements: { item },
+		states: { activeHeadingIdxs, headingsTree }
+	} = createTableOfContents({
+		selector: '#toc-builder-preview',
+		exclude: [],
+		activeType: 'highest',
+		pushStateFn: pushState,
+		headingFilterFn: (heading) => !heading.hasAttribute('data-toc-ignore'),
+
+		scrollFn: (id) => {
+			const container = document.getElementById('toc-builder-preview');
+			const element = document.getElementById(id);
+
+			if (container && element) {
+				const containerTopOffset = container.offsetTop;
+				const elementTopOffset = element.offsetTop;
+
+				if (isMobileScreen) {
+					element.scrollIntoView({
+						behavior: 'smooth',
+						block: 'start'
+					});
+				} else {
+					container.scrollTo({
+						top: elementTopOffset - containerTopOffset,
+						behavior: 'smooth'
+					});
+				}
+			}
+		}
+	});
+</script>
+
+<div class="lg:overflow-y-auto rounded-lg text-white">
+	<nav>
+		{#key $headingsTree}
+			<Tree tree={$headingsTree} activeHeadingIdxs={$activeHeadingIdxs} {item} />
+		{/key}
+	</nav>
+</div>

--- a/src/lib/components/atoms/Tree.svelte
+++ b/src/lib/components/atoms/Tree.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { type TableOfContentsItem, type TableOfContentsElements, melt } from '@melt-ui/svelte';
+
+	export let tree: TableOfContentsItem[] = [];
+	export let activeHeadingIdxs: number[];
+	export let item: TableOfContentsElements['item'];
+	export let level = 1;
+</script>
+
+<ul class="mt-0 list-none {level !== 1 ? 'pl-4' : ''}">
+	{#if tree && tree.length}
+		{#each tree as heading, i (i)}
+			<li class="mt-0 pt-2">
+				<a
+					href="#{heading.id}"
+					use:melt={$item(heading.id)}
+					class="inline-flex items-center justify-center gap-1 text-white no-underline transition-colors
+             hover:text-[rgba(255,_49,_0,_1)] data-[active]:text-[rgba(255,_49,_0,_1)]"
+				>
+					<!--
+              Along with the heading title, the original heading node
+              is also passed down, so you can display headings
+              however you want.
+            -->
+					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+					{@html heading.node.innerHTML}
+				</a>
+				{#if heading.children && heading.children.length}
+					<svelte:self tree={heading.children} level={level + 1} {activeHeadingIdxs} {item} />
+				{/if}
+			</li>
+		{/each}
+	{/if}
+</ul>
+
+<style>
+	a {
+		word-break: keep-all;
+	}
+</style>

--- a/src/lib/components/molecules/CardContainer.svelte
+++ b/src/lib/components/molecules/CardContainer.svelte
@@ -19,7 +19,9 @@
 			grid-template-columns: repeat(2, 1fr);
 			grid-template-rows: repeat(1, 1fr);
 			grid-column-gap: 24px;
-			grid-row-gap: 24px;
+			grid-row-gap: 2px;
+			max-width: 1200px;
+			padding-inline: 1.5rem;
 		}
 	}
 

--- a/src/lib/components/organisms/Header.svelte
+++ b/src/lib/components/organisms/Header.svelte
@@ -84,6 +84,7 @@
 			align-items: center;
 			width: 100%;
 			margin: 0 auto;
+			padding-top: 0.25rem;
 
 			@include for-phone-only {
 				height: 64px;

--- a/src/lib/components/organisms/Hero.svelte
+++ b/src/lib/components/organisms/Hero.svelte
@@ -67,6 +67,7 @@
 			font-size: 48px;
 			margin-top: 2rem;
 			line-height: 48px;
+			font-weight: bold;
 		}
 
 		p {

--- a/src/lib/components/singletons/TorrustIndexPost.svelte
+++ b/src/lib/components/singletons/TorrustIndexPost.svelte
@@ -1,38 +1,13 @@
 <script lang="ts">
-	import TableOfContents from '$lib/components/atoms/TableOfContents.svelte'; // Adjust the path if needed
 	import CodeBlock from '$lib/components/molecules/CodeBlock.svelte';
-
-	// Array of section objects with display names and IDs
-	let sections = [
-		{
-			name: 'Installation',
-			id: 'installation',
-			subsections: [
-				{ name: 'Software requirements', id: 'softwareRequirements' },
-				{ name: 'Build from sources', id: 'buildSources' },
-				{ name: 'Run with docker', id: 'docker' }
-			]
-		},
-		{ name: 'Roadmap', id: 'roadmap' },
-		{
-			name: 'License',
-			id: 'license',
-			subsections: [
-				{ name: 'Copyright', id: 'copyright' },
-				{ name: 'Legacy Exception', id: 'legacyException' }
-			]
-		}
-	];
-
-	let activeSection = '';
+	import Toc from '../atoms/Toc.svelte';
+	import PagesWrapper from '../atoms/PagesWrapper.svelte';
 </script>
 
-<div class="layout">
-	<div>
-		<TableOfContents {sections} {activeSection} />
-	</div>
+<PagesWrapper heading="">
+	<Toc />
 
-	<div class="content">
+	<div id="toc-builder-preview" class="content-preview">
 		<h2 id="installation">Installation</h2>
 
 		<p>
@@ -245,55 +220,47 @@ cd /tmp \
 			> license.
 		</p>
 	</div>
-</div>
+</PagesWrapper>
 
 <style lang="scss">
 	@import '$lib/scss/breakpoints.scss';
 
-	.layout {
-		padding-inline: 1.5rem;
-		margin-top: 8rem;
-		border: 1px solid transparent;
+	.content-preview {
+		flex: 1;
+		word-break: keep-all;
+		padding-top: 2rem;
 	}
 
-	.content {
-		margin-top: 2rem;
-	}
-
-	/*h1 {
-		padding-top: 1rem;
-		font-size: 2.25rem;
-	}*/
-
-	h2 {
-		padding-top: 0.5rem;
+	#toc-builder-preview > h2 {
 		font-size: 1.8rem;
 	}
 
-	h2:not(:first-of-type) {
-		padding-top: 1.5rem; /* Add top padding to all h2 elements except the first one */
+	#toc-builder-preview > h2:not(:first-of-type) {
+		padding-top: 1.5rem;
 	}
 
-	h3 {
-		padding-top: 2rem;
+	#toc-builder-preview > h3 {
 		font-size: 1.3rem;
+		font-weight: bold;
+		padding-top: 1rem;
 	}
 
 	p {
 		font-size: 1rem;
 		padding-top: 1.5rem;
 		color: rgba(245, 245, 245, 0.8);
+		word-break: keep-all;
+	}
+
+	a {
+		word-break: keep-all;
+		color: rgba(255, 49, 0, 1);
 	}
 
 	@include for-desktop-up {
-		.layout {
-			display: flex;
-			gap: 2rem;
-			padding-inline: 0rem;
-		}
-
-		.content {
-			margin-top: 0rem;
+		.content-preview {
+			overflow-y: auto;
+			padding-top: 0rem;
 		}
 	}
 </style>

--- a/src/lib/components/singletons/TorrustTrackerPost.svelte
+++ b/src/lib/components/singletons/TorrustTrackerPost.svelte
@@ -1,33 +1,12 @@
 <script lang="ts">
-	import TableOfContents from '$lib/components/atoms/TableOfContents.svelte'; // Adjust the path if needed
 	import CodeBlock from '$lib/components/molecules/CodeBlock.svelte';
-
-	// Array of section objects with display names and IDs
-	let sections = [
-		{ name: 'Installation', id: 'installation' },
-		{ name: 'Software requirements', id: 'softwareRequirements' },
-		{ name: 'Build from sources', id: 'buildSources' },
-		{ name: 'Run with docker', id: 'docker' },
-		{ name: 'Roadmap', id: 'roadmap' },
-		{
-			name: 'License',
-			id: 'license',
-			subsections: [
-				{ name: 'Copyright', id: 'copyright' },
-				{ name: 'Legacy Exception', id: 'legacyException' }
-			]
-		}
-	];
-
-	let activeSection = '';
+	import Toc from '../atoms/Toc.svelte';
+	import PagesWrapper from '../atoms/PagesWrapper.svelte';
 </script>
 
-<div class="layout">
-	<div>
-		<TableOfContents {sections} {activeSection} />
-	</div>
-
-	<div class="content">
+<PagesWrapper heading="">
+	<Toc />
+	<div id="toc-builder-preview" class="content-preview">
 		<h2 id="installation">Installation</h2>
 
 		<p>
@@ -257,44 +236,47 @@ cd /tmp \
 			> license.
 		</p>
 	</div>
-</div>
+</PagesWrapper>
 
 <style lang="scss">
 	@import '$lib/scss/breakpoints.scss';
 
-	.layout {
-		padding-inline: 1.5rem;
-		margin-top: 8rem;
-		border: 1px solid transparent;
+	.content-preview {
+		flex: 1;
+		word-break: keep-all;
+		padding-top: 2rem;
 	}
 
-	.content {
-		margin-top: 3rem;
+	#toc-builder-preview > h2 {
+		font-size: 1.8rem;
 	}
 
-	h2 {
-		font-size: 1.875rem;
+	#toc-builder-preview > h2:not(:first-of-type) {
+		padding-top: 1.5rem;
 	}
 
-	h2:not(:first-of-type) {
-		padding-top: 1.5rem; /* Add top padding to all h2 elements except the first one */
+	#toc-builder-preview > h3 {
+		font-size: 1.3rem;
+		font-weight: bold;
+		padding-top: 1rem;
 	}
 
 	p {
 		font-size: 1rem;
 		padding-top: 1.5rem;
 		color: rgba(245, 245, 245, 0.8);
+		word-break: keep-all;
+	}
+
+	a {
+		word-break: keep-all;
+		color: rgba(255, 49, 0, 1);
 	}
 
 	@include for-desktop-up {
-		.layout {
-			display: flex;
-			gap: 2rem;
-			padding-inline: 0rem;
-		}
-
-		.content {
-			margin-top: 0rem;
+		.content-preview {
+			overflow-y: auto;
+			padding-top: 0rem;
 		}
 	}
 </style>

--- a/src/lib/components/singletons/WhyContribute.svelte
+++ b/src/lib/components/singletons/WhyContribute.svelte
@@ -32,6 +32,12 @@
 		background: rgba(26, 26, 26, 1);
 		padding-top: 4rem;
 		padding-inline: 1.5rem;
+		max-width: 1200px;
+
+		h2 {
+			font-size: 1.8rem;
+			font-weight: bold;
+		}
 
 		p {
 			margin-top: 1.5rem;

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -663,287 +663,46 @@ export const trackerTableData = [
 	}
 ];
 
-export interface TableItem {
-	heading: string;
-	link: string;
-	subheadings: { heading: string; link: string }[];
-}
-
-export const indexTable: TableItem[] = [
-	{
-		heading: 'Installation',
-		link: 'installation',
-		subheadings: [
-			{
-				heading: 'Software requirements',
-				link: 'softwareRequirements'
-			},
-			{
-				heading: 'Build from sources (Rust)',
-				link: 'buildSources'
-			},
-			{
-				heading: 'Docker',
-				link: 'docker'
-			}
-		]
-	},
-	{
-		heading: 'Licenses',
-		link: 'licenses',
-		subheadings: [
-			{
-				heading: 'Copyright (c) 2023 The Torrust Developers',
-				link: 'copyright'
-			},
-			{
-				heading: 'Legacy Exception',
-				link: 'legacyException'
-			}
-		]
-	},
-	{
-		heading: 'Roadmap',
-		link: 'roadmap',
-		subheadings: [
-			{
-				heading: 'Future Features',
-				link: 'futureFeatures'
-			}
-		]
-	}
+export const aboutTableHeadings = [
+	{ displayName: 'Feature', fieldName: 'feature' },
+	{ displayName: 'BitTorrent', fieldName: 'bittorrent' },
+	{ displayName: 'IPFS', fieldName: 'ipfs' }
 ];
 
-export const trackerTable: TableItem[] = [
+export const aboutTableData = [
 	{
-		heading: 'Installation',
-		link: 'installation',
-		subheadings: [
-			{
-				heading: 'Software requirements',
-				link: 'softwareRequirements'
-			},
-			{
-				heading: 'Build from sources (Rust)',
-				link: 'buildSources'
-			},
-			{
-				heading: 'Docker',
-				link: 'docker'
-			}
-		]
+		feature: 'File Identification',
+		bittorrent: 'By location (via torrents and trackers)',
+		ipfs: 'By content (using cryptographic hashes)'
 	},
 	{
-		heading: 'Licenses',
-		link: 'licenses',
-		subheadings: [
-			{
-				heading: 'Copyright (c) 2023 The Torrust Developers',
-				link: 'copyright'
-			},
-			{
-				heading: 'Build from sources (Rust)',
-				link: 'buildSources'
-			}
-		]
+		feature: 'File Availability',
+		bittorrent: 'Depends on seeders',
+		ipfs: 'Persisted via pinning or multiple nodes'
 	},
 	{
-		heading: 'Roadmap',
-		link: 'roadmap',
-		subheadings: [
-			{
-				heading: 'Core',
-				link: 'core'
-			},
-			{
-				heading: 'Persistence',
-				link: 'persistence'
-			},
-			{
-				heading: 'Performance',
-				link: 'performance'
-			},
-			{
-				heading: 'Protocols',
-				link: 'protocols'
-			},
-			{
-				heading: 'Integrations',
-				link: 'integrations'
-			},
-			{
-				heading: 'Utils',
-				link: 'utils'
-			},
-			{
-				heading: 'Others',
-				link: 'others'
-			}
-		]
-	}
-];
-
-export const selfHostTable: TableItem[] = [
-	{
-		heading: 'Torrent solution (Index + Tracker)',
-		link: '#torrustSolution',
-		subheadings: [
-			{
-				heading: 'Build from sources (Rust)',
-				link: '#buildSources'
-			},
-			{
-				heading: 'Docker',
-				link: '#docker'
-			},
-			{
-				heading: 'Tutorials',
-				link: '#tutorials'
-			}
-		]
+		feature: 'Architecture',
+		bittorrent: 'Peer-to-peer, maximally decentralized	',
+		ipfs: 'Peer-to-peer, with global content addressing'
 	},
 	{
-		heading: 'Torrust tracker',
-		link: 'torrustTracker',
-		subheadings: []
-	}
-];
-
-export const communityTable: TableItem[] = [
-	{
-		heading: 'Why Contribute?',
-		link: 'whyContribute',
-		subheadings: [
-			{
-				heading: 'Embrace Rust: a language of choice',
-				link: 'embraceRust'
-			},
-			{
-				heading: 'Code quality above all',
-				link: 'codeQuality'
-			},
-			{
-				heading: 'A welcoming community for newcomers',
-				link: 'welcomingCommunity'
-			},
-			{
-				heading: 'Influence the project’s direction',
-				link: 'influenceDirection'
-			},
-			{
-				heading: 'Join us today',
-				link: 'joinUs'
-			}
-		]
+		feature: 'File Hosting',
+		bittorrent: 'Temporary (as long as seeders exist)',
+		ipfs: 'Permanent (with pinning services)'
 	},
 	{
-		heading: 'How to contribute?',
-		link: 'howContribute',
-		subheadings: []
+		feature: 'Resource Use',
+		bittorrent: 'Lightweight',
+		ipfs: 'More resource-intensive'
 	},
 	{
-		heading: 'Knowledge Base',
-		link: 'knowledgeBase',
-		subheadings: [
-			{
-				heading: 'What are Torrents?',
-				link: 'whatAreTorrents'
-			},
-			{
-				heading: 'What Is a Tracker?',
-				link: 'whatIsTracker'
-			},
-			{
-				heading: 'What Is a Torrent Index',
-				link: 'whatIsTorrentIndex'
-			},
-			{
-				heading: 'List of projects using BitTorrent',
-				link: 'listOfProjects'
-			}
-		]
+		feature: 'Use of DHT',
+		bittorrent: 'For finding peers',
+		ipfs: 'For finding content providers'
 	},
 	{
-		heading: 'Resources',
-		link: 'resources',
-		subheadings: []
-	}
-];
-
-export const aboutTable: TableItem[] = [
-	{
-		heading: 'Why BitTorrent?',
-		link: 'bitTorrent',
-		subheadings: [
-			{
-				heading: 'Why does the BitTorrent protocol still matter?',
-				link: 'bitTorrentProtocol'
-			},
-			{
-				heading: 'Efficiency and scalability',
-				link: 'efficiency'
-			},
-			{
-				heading: 'Current use cases',
-				link: 'currentUses'
-			},
-			{
-				heading: 'Future use cases',
-				link: 'futureUses'
-			},
-			{
-				heading: 'BT vs. IPFS',
-				link: 'btIpfs'
-			},
-			{
-				heading: 'BT vs. centralized solutions',
-				link: 'btCs'
-			},
-			{
-				heading: 'Conclusion',
-				link: 'conclusion'
-			}
-		]
-	},
-	{
-		heading: 'Why Torrust?',
-		link: 'whyTorrust',
-		subheadings: [
-			{
-				heading: 'Performance & Efficiency',
-				link: 'performanceEfficiency'
-			},
-			{
-				heading: 'Security & Reliability',
-				link: 'securityReliability'
-			},
-			{
-				heading: 'User Experience & Accessibility',
-				link: 'userExperience'
-			},
-			{
-				heading: 'Future-Proofing and Innovation',
-				link: 'futureProofing'
-			},
-			{
-				heading: 'Integration & Interoperability',
-				link: 'integration'
-			}
-		]
-	},
-	{
-		heading: 'The Team',
-		link: 'team',
-		subheadings: []
-	},
-	{
-		heading: 'Collaborators',
-		link: 'collaborators',
-		subheadings: []
-	},
-	{
-		heading: 'Sponsors',
-		link: 'sponsors',
-		subheadings: []
+		feature: 'Security',
+		bittorrent: 'Less focused on content validation',
+		ipfs: 'Cryptographic validation of all content'
 	}
 ];

--- a/src/lib/scss/_typography.scss
+++ b/src/lib/scss/_typography.scss
@@ -32,7 +32,7 @@ i {
 }
 
 ul li::marker {
-	color: rgba(255, 49, 0, 0.96); /* Change the bullet color to red */
+	color: rgba(255, 49, 0, 0.96) !important;
 }
 
 // #region Titles
@@ -46,7 +46,7 @@ h1 {
 }
 
 h2 {
-	font-size: 1.8rem;
+	font-size: 1.8rem !important;
 	font-weight: 600;
 }
 

--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -50,6 +50,8 @@
 		text-align: center;
 		color: rgba(245, 245, 245, 0.96);
 		padding-top: 4rem;
+		font-size: 1.8rem;
+		font-weight: bold;
 	}
 
 	.grid {

--- a/src/routes/(pages)/about/+page.svelte
+++ b/src/routes/(pages)/about/+page.svelte
@@ -1,491 +1,402 @@
 <script>
-	import TableOfContents from '$lib/components/atoms/TableOfContents.svelte'; // Adjust the path if needed
+	import Toc from '$lib/components/atoms/Toc.svelte';
 	import Table from '$lib/components/atoms/Table.svelte';
+	import PagesWrapper from '$lib/components/atoms/PagesWrapper.svelte';
 
-	// Array of section objects with display names and IDs
-	let sections = [
-		{
-			name: 'Why BitTorrent?',
-			id: 'bitTorrent',
-			subsections: [
-				{ name: 'Why does the BitTorrent protocol still matter?', id: 'bitTorrentProtocol' },
-				{ name: 'Efficiency and scalability', id: 'efficiency' },
-				{ name: 'Current use cases', id: 'currentUses' },
-				{ name: 'Future use cases', id: 'futureUses' },
-				{ name: 'BT vs. IPFS', id: 'btIpfs' },
-				{ name: 'Conclusion', id: 'conclusion' }
-			]
-		},
-		{
-			name: 'Why Torrust',
-			id: 'whyTorrust',
-			subsections: [
-				{ name: 'Performance & Efficiency', id: 'performanceEfficiency' },
-				{ name: 'Security & Reliability', id: 'securityReliability' },
-				{ name: 'User Experience & Accessibility', id: 'userExperience' },
-				{ name: 'Integration & Interoperability', id: 'integration' }
-			]
-		},
-		{ name: 'The Team', id: 'team' },
-		{ name: 'Contributors', id: 'contributors' },
-		{ name: 'Sponsors', id: 'sponsors' }
-	];
-
-	let activeSection = '';
-
-	const tableHeadings = [
-		{ displayName: 'Feature', fieldName: 'feature' },
-		{ displayName: 'BitTorrent', fieldName: 'bittorrent' },
-		{ displayName: 'IPFS', fieldName: 'ipfs' }
-	];
-
-	const tableData = [
-		{
-			feature: 'File Identification',
-			bittorrent: 'By location (via torrents and trackers)',
-			ipfs: 'By content (using cryptographic hashes)'
-		},
-		{
-			feature: 'File Availability',
-			bittorrent: 'Depends on seeders',
-			ipfs: 'Persisted via pinning or multiple nodes'
-		},
-		{
-			feature: 'Architecture',
-			bittorrent: 'Peer-to-peer, maximally decentralized	',
-			ipfs: 'Peer-to-peer, with global content addressing'
-		},
-		{
-			feature: 'File Hosting',
-			bittorrent: 'Temporary (as long as seeders exist)',
-			ipfs: 'Permanent (with pinning services)'
-		},
-		{
-			feature: 'Resource Use',
-			bittorrent: 'Lightweight',
-			ipfs: 'More resource-intensive'
-		},
-		{
-			feature: 'Use of DHT',
-			bittorrent: 'For finding peers',
-			ipfs: 'For finding content providers'
-		},
-		{
-			feature: 'Security',
-			bittorrent: 'Less focused on content validation',
-			ipfs: 'Cryptographic validation of all content'
-		}
-	];
+	import { aboutTableHeadings, aboutTableData } from '$lib/constants/constants';
 </script>
 
-<div class="container">
-	<h1>About</h1>
-	<div class="layout">
-		<div class="toc">
-			<TableOfContents {sections} {activeSection} />
-		</div>
-		<div class="content">
-			<h2 id="bitTorrent">Why BitTorrent?</h2>
+<PagesWrapper heading="About">
+	<Toc />
+	<div id="toc-builder-preview" class="content-preview">
+		<h2>Why BitTorrent?</h2>
 
-			<p>
-				In a world driven by digital content, the BitTorrent protocol remains a cornerstone for
-				decentralized, efficient file sharing. While newer technologies such as IPFS and cloud
-				storage solutions have emerged, BitTorrent continues to serve a critical role in enabling
-				large-scale data distribution with unparalleled efficiency and scalability.
-			</p>
+		<p>
+			In a world driven by digital content, the BitTorrent protocol remains a cornerstone for
+			decentralized, efficient file sharing. While newer technologies such as IPFS and cloud storage
+			solutions have emerged, BitTorrent continues to serve a critical role in enabling large-scale
+			data distribution with unparalleled efficiency and scalability.
+		</p>
 
-			<h3 id="bitTorrentProtocol">Why does the BitTorrent protocol still matter?</h3>
+		<h3>Why does the BitTorrent protocol still matter?</h3>
 
-			<p>
-				Despite the rise of centralized alternatives and new distributed systems, the BitTorrent
-				protocol remains a key player in the digital landscape. Its decentralized nature ensures
-				that users maintain control over data distribution, making it a critical tool in today's
-				interconnected world. The focus on distributing content without over-reliance on a single
-				server continues to make BitTorrent relevant for various use cases, from media sharing to
-				large-scale software updates.
-			</p>
+		<p>
+			Despite the rise of centralized alternatives and new distributed systems, the BitTorrent
+			protocol remains a key player in the digital landscape. Its decentralized nature ensures that
+			users maintain control over data distribution, making it a critical tool in today's
+			interconnected world. The focus on distributing content without over-reliance on a single
+			server continues to make BitTorrent relevant for various use cases, from media sharing to
+			large-scale software updates.
+		</p>
 
-			<p>
-				In the rapidly evolving landscape of digital technology, the BitTorrent protocol remains a
-				cornerstone for distributed file sharing. Despite the emergence of newer technologies like
-				the
-				<a href="https://ipfs.tech/">InterPlanetary File System</a>
-				(IPFS) and centralized cloud storage solutions such as Dropbox, Google Drive, and Amazon S3,
-				BitTorrent continues to hold significant relevance. Here's why maintaining and enhancing BitTorrent
-				is not just worthwhile but essential.
-			</p>
+		<p>
+			In the rapidly evolving landscape of digital technology, the BitTorrent protocol remains a
+			cornerstone for distributed file sharing. Despite the emergence of newer technologies like the
+			<a href="https://ipfs.tech/">InterPlanetary File System</a>
+			(IPFS) and centralized cloud storage solutions such as Dropbox, Google Drive, and Amazon S3, BitTorrent
+			continues to hold significant relevance. Here's why maintaining and enhancing BitTorrent is not
+			just worthwhile but essential.
+		</p>
 
-			<p>
-				<img src="images/net.jpeg" alt="A network with interconnected wires" />
-			</p>
+		<p>
+			<img src="images/net.jpeg" alt="A network with interconnected wires" />
+		</p>
 
-			<h3 id="efficiency">Efficiency and scalability</h3>
+		<h3>Efficiency and scalability</h3>
 
-			<p>
-				BitTorrent excels in efficiently distributing large files across the internet. By allowing
-				users to download and upload pieces of files simultaneously from multiple sources, it
-				minimizes server load and avoids bottlenecks. This peer-to-peer approach scales naturally
-				with the number of users, making it exceptionally effective for sharing large datasets,
-				media files, and software distributions.
-			</p>
+		<p>
+			BitTorrent excels in efficiently distributing large files across the internet. By allowing
+			users to download and upload pieces of files simultaneously from multiple sources, it
+			minimizes server load and avoids bottlenecks. This peer-to-peer approach scales naturally with
+			the number of users, making it exceptionally effective for sharing large datasets, media
+			files, and software distributions.
+		</p>
 
-			<h3 id="currentUses">Current use cases</h3>
+		<h3>Current use cases</h3>
 
-			<p>
-				<strong>Media Distribution:</strong> Independent creators and open-source projects often use
-				BitTorrent to distribute content without incurring high bandwidth costs.
-			</p>
+		<p>
+			<strong>Media Distribution:</strong> Independent creators and open-source projects often use BitTorrent
+			to distribute content without incurring high bandwidth costs.
+		</p>
 
-			<p>
-				<strong>Software Updates:</strong> Some companies distribute updates and patches for their software
-				via BitTorrent to reduce the strain on their servers.
-			</p>
+		<p>
+			<strong>Software Updates:</strong> Some companies distribute updates and patches for their software
+			via BitTorrent to reduce the strain on their servers.
+		</p>
 
-			<p>
-				<strong>Data Archiving:</strong> Academic and research institutions use BitTorrent for archiving
-				and sharing large datasets and publications.
-			</p>
+		<p>
+			<strong>Data Archiving:</strong> Academic and research institutions use BitTorrent for archiving
+			and sharing large datasets and publications.
+		</p>
 
-			<h3 id="futureUses">Future use cases</h3>
+		<h3>Future use cases</h3>
 
-			<p>
-				<strong>Decentralized Internet:</strong> BitTorrent can play a crucial role in the development
-				of a decentralized web, where content is distributed and accessed without centralized control.
-			</p>
+		<p>
+			<strong>Decentralized Internet:</strong> BitTorrent can play a crucial role in the development
+			of a decentralized web, where content is distributed and accessed without centralized control.
+		</p>
 
-			<p>
-				<strong>Blockchain and Cryptocurrency:</strong> Integrating BitTorrent with blockchain technology
-				could lead to innovative content distribution models, rewarding content creators and sharers
-				directly.
-			</p>
+		<p>
+			<strong>Blockchain and Cryptocurrency:</strong> Integrating BitTorrent with blockchain technology
+			could lead to innovative content distribution models, rewarding content creators and sharers directly.
+		</p>
 
-			<p>
-				<strong>Emergency Communications:</strong> In scenarios where traditional communication infrastructures
-				fail, BitTorrent can facilitate the sharing of information and emergency updates.
-			</p>
+		<p>
+			<strong>Emergency Communications:</strong> In scenarios where traditional communication infrastructures
+			fail, BitTorrent can facilitate the sharing of information and emergency updates.
+		</p>
 
-			<h3 id="btIpfs">BT vs. IPFS</h3>
+		<h3>BT vs. IPFS</h3>
 
-			<p>
-				BitTorrent and IPFS are both decentralized file-sharing technologies, but they differ
-				fundamentally in how they operate.
-			</p>
+		<p>
+			BitTorrent and IPFS are both decentralized file-sharing technologies, but they differ
+			fundamentally in how they operate.
+		</p>
 
-			<p>
-				The key differences are:: 1. <strong>Content Addressing</strong>: BitTorrent identifies
-				files by their location on specific peers, while IPFS uses content-addressing, meaning files
-				are found by their unique cryptographic hash, regardless of their location. 2.
-				<strong>Architecture</strong>: BitTorrent focuses on maximizing decentralization with
-				seeders and leechers. IPFS builds a global namespace where files are persistently available
-				as long as they are "pinned." 3. <strong>File Availability</strong>: In BitTorrent, content
-				is only available as long as seeders are present. In contrast, IPFS ensures availability by
-				storing content through pinning services and distributed nodes. 4.
-				<strong>Protocol Overhead</strong>: BitTorrent is more lightweight in resource consumption
-				compared to IPFS, which can be more intensive due to its routing mechanisms and use of
-				Distributed Hash Tables (DHT).
-			</p>
-			<p>Here’s a comparison table for key features:</p>
+		<p>
+			The key differences are:: 1. <strong>Content Addressing</strong>: BitTorrent identifies files
+			by their location on specific peers, while IPFS uses content-addressing, meaning files are
+			found by their unique cryptographic hash, regardless of their location. 2.
+			<strong>Architecture</strong>: BitTorrent focuses on maximizing decentralization with seeders
+			and leechers. IPFS builds a global namespace where files are persistently available as long as
+			they are "pinned." 3. <strong>File Availability</strong>: In BitTorrent, content is only
+			available as long as seeders are present. In contrast, IPFS ensures availability by storing
+			content through pinning services and distributed nodes. 4.
+			<strong>Protocol Overhead</strong>: BitTorrent is more lightweight in resource consumption
+			compared to IPFS, which can be more intensive due to its routing mechanisms and use of
+			Distributed Hash Tables (DHT).
+		</p>
+		<p>Here’s a comparison table for key features:</p>
 
-			<Table tableHeading={tableHeadings} {tableData} />
+		<Table tableHeading={aboutTableHeadings} tableData={aboutTableData} />
 
-			<h3 id="btCs">BT vs. centralized solutions</h3>
+		<h3>BT vs. centralized solutions</h3>
 
-			<p>
-				Centralized cloud storage services like Dropbox, Google Drive, and Amazon S3 offer
-				convenience and integration with various applications. However, they rely on central
-				servers, which can become points of failure or targets for censorship. BitTorrent's
-				decentralized nature inherently protects against these issues, offering resilience and
-				freedom from control by any single entity.
-			</p>
+		<p>
+			Centralized cloud storage services like Dropbox, Google Drive, and Amazon S3 offer convenience
+			and integration with various applications. However, they rely on central servers, which can
+			become points of failure or targets for censorship. BitTorrent's decentralized nature
+			inherently protects against these issues, offering resilience and freedom from control by any
+			single entity.
+		</p>
 
-			<h3 id="conclusion">Conclusion</h3>
+		<h3>Conclusion</h3>
 
-			<p>
-				The continued relevance of BitTorrent lies in its unparalleled efficiency, scalability, and
-				its foundation for a more decentralized internet. While newer technologies like IPFS offer
-				compelling advancements, BitTorrent's unique strengths in supporting dynamic content and its
-				established infrastructure make it irreplaceable. As digital content continues to grow in
-				size and volume, the importance of efficient, decentralized distribution networks becomes
-				ever more critical. Investing in the maintenance and improvement of BitTorrent is not just
-				about preserving a technology; it's about sustaining a vision for an open, scalable, and
-				resilient internet.
-			</p>
+		<p>
+			The continued relevance of BitTorrent lies in its unparalleled efficiency, scalability, and
+			its foundation for a more decentralized internet. While newer technologies like IPFS offer
+			compelling advancements, BitTorrent's unique strengths in supporting dynamic content and its
+			established infrastructure make it irreplaceable. As digital content continues to grow in size
+			and volume, the importance of efficient, decentralized distribution networks becomes ever more
+			critical. Investing in the maintenance and improvement of BitTorrent is not just about
+			preserving a technology; it's about sustaining a vision for an open, scalable, and resilient
+			internet.
+		</p>
 
-			<h2 id="whyTorrust">Why Torrust</h2>
+		<h2>Why Torrust</h2>
 
-			<p>
-				Developing new tools for BitTorrent in modern programming languages like Rust, along with
-				more contemporary interfaces, is essential for several reasons. These developments not only
-				align with current technological trends but also address evolving user needs and security
-				concerns. Here are some key points illustrating the necessity of these advancements:
-			</p>
+		<p>
+			Developing new tools for BitTorrent in modern programming languages like Rust, along with more
+			contemporary interfaces, is essential for several reasons. These developments not only align
+			with current technological trends but also address evolving user needs and security concerns.
+			Here are some key points illustrating the necessity of these advancements:
+		</p>
 
-			<h3 id="performanceEfficiency">Performance & Efficiency</h3>
+		<h3>Performance & Efficiency</h3>
 
-			<ul>
-				<li>
-					<strong>High Performance:</strong> Rust offers exceptional speed and efficiency, which can
-					significantly improve the performance of BitTorrent tools. Its focus on concurrency and memory
-					safety allows for the development of high-speed data transmission tools without the common
-					pitfalls of memory leaks and crashes.
-				</li>
-				<li>
-					<strong>Resource Optimization:</strong> Modern devices vary widely in their capabilities. Developing
-					new tools in Rust can help optimize resource use, making BitTorrent more accessible on a wider
-					range of devices, from high-end servers to low-powered IoT devices.
-				</li>
-			</ul>
+		<ul>
+			<li>
+				<strong>High Performance:</strong> Rust offers exceptional speed and efficiency, which can significantly
+				improve the performance of BitTorrent tools. Its focus on concurrency and memory safety allows
+				for the development of high-speed data transmission tools without the common pitfalls of memory
+				leaks and crashes.
+			</li>
+			<li>
+				<strong>Resource Optimization:</strong> Modern devices vary widely in their capabilities. Developing
+				new tools in Rust can help optimize resource use, making BitTorrent more accessible on a wider
+				range of devices, from high-end servers to low-powered IoT devices.
+			</li>
+		</ul>
 
-			<h3 id="securityReliability">Security & Reliability</h3>
+		<h3>Security & Reliability</h3>
 
-			<ul>
-				<li>
-					<strong>Memory Safety:</strong> Rust's emphasis on memory safety without a garbage collector
-					minimizes common security vulnerabilities found in other languages, such as buffer overflows
-					and dangling pointers. This is crucial for peer-to-peer networks that are inherently exposed
-					to data from untrusted sources.
-				</li>
-				<li>
-					<strong>Dependability:</strong> By leveraging Rust's type system and ownership model, developers
-					can build more reliable applications that are less prone to crashes and unexpected behavior,
-					enhancing the user experience.
-				</li>
-			</ul>
+		<ul>
+			<li>
+				<strong>Memory Safety:</strong> Rust's emphasis on memory safety without a garbage collector
+				minimizes common security vulnerabilities found in other languages, such as buffer overflows
+				and dangling pointers. This is crucial for peer-to-peer networks that are inherently exposed
+				to data from untrusted sources.
+			</li>
+			<li>
+				<strong>Dependability:</strong> By leveraging Rust's type system and ownership model, developers
+				can build more reliable applications that are less prone to crashes and unexpected behavior,
+				enhancing the user experience.
+			</li>
+		</ul>
 
-			<h3 id="userExperience">User Experience & Accessibility</h3>
+		<h3>User Experience & Accessibility</h3>
 
-			<ul>
-				<li>
-					<strong>Modern Interfaces:</strong> Updating BitTorrent clients with modern, user-friendly
-					interfaces can make the technology more accessible to a broader audience, encouraging adoption.
-					Simplifying the user experience without compromising on advanced features appeals to both novice
-					and experienced users.
-				</li>
-				<li>
-					<strong>Cross-Platform Compatibility:</strong>Developing with modern frameworks and
-					languages supports better cross-platform compatibility, ensuring a consistent and
-					functional experience across various operating systems and devices.
-				</li>
-			</ul>
+		<ul>
+			<li>
+				<strong>Modern Interfaces:</strong> Updating BitTorrent clients with modern, user-friendly interfaces
+				can make the technology more accessible to a broader audience, encouraging adoption. Simplifying
+				the user experience without compromising on advanced features appeals to both novice and experienced
+				users.
+			</li>
+			<li>
+				<strong>Cross-Platform Compatibility:</strong>Developing with modern frameworks and
+				languages supports better cross-platform compatibility, ensuring a consistent and functional
+				experience across various operating systems and devices.
+			</li>
+		</ul>
 
-			<h3 id="futureProofing">Future-Proofing & Innovation</h3>
+		<h3>Future-Proofing & Innovation</h3>
 
-			<ul>
-				<li>
-					<strong>Adapting to Technological Advances:</strong> The digital landscape is constantly evolving.
-					Developing new tools with modern languages ensures compatibility with the latest technologies
-					and standards, making BitTorrent more adaptable and future-proof.
-				</li>
-				<li>
-					<strong>Encouraging Innovation:</strong>By embracing modern programming paradigms and
-					languages, the BitTorrent ecosystem can stimulate innovation, leading to the development
-					of new features, improved efficiency, and potentially new use cases for distributed file
-					sharing.
-				</li>
-			</ul>
+		<ul>
+			<li>
+				<strong>Adapting to Technological Advances:</strong> The digital landscape is constantly evolving.
+				Developing new tools with modern languages ensures compatibility with the latest technologies
+				and standards, making BitTorrent more adaptable and future-proof.
+			</li>
+			<li>
+				<strong>Encouraging Innovation:</strong>By embracing modern programming paradigms and
+				languages, the BitTorrent ecosystem can stimulate innovation, leading to the development of
+				new features, improved efficiency, and potentially new use cases for distributed file
+				sharing.
+			</li>
+		</ul>
 
-			<h3 id="integration">Integration & Interoperability</h3>
+		<h3>Integration & Interoperability</h3>
 
-			<ul>
-				<li>
-					<strong>Blockchain & Beyond:</strong>The integration of BitTorrent with emerging
-					technologies like blockchain and decentralized finance (DeFi) requires a modern approach
-					to ensure seamless interoperability and to unlock new functionalities and business models.
-				</li>
-				<li>
-					<strong>Ecosystem Synergy:</strong>Developing tools in languages like Rust promotes
-					synergy within the ecosystem, as Rust is increasingly used in networked applications,
-					cryptocurrency platforms, and other areas relevant to BitTorrent's growth and integration.
-				</li>
-			</ul>
+		<ul>
+			<li>
+				<strong>Blockchain & Beyond:</strong>The integration of BitTorrent with emerging
+				technologies like blockchain and decentralized finance (DeFi) requires a modern approach to
+				ensure seamless interoperability and to unlock new functionalities and business models.
+			</li>
+			<li>
+				<strong>Ecosystem Synergy:</strong>Developing tools in languages like Rust promotes synergy
+				within the ecosystem, as Rust is increasingly used in networked applications, cryptocurrency
+				platforms, and other areas relevant to BitTorrent's growth and integration.
+			</li>
+		</ul>
 
-			<p>
-				In conclusion, the development of new BitTorrent tools in Rust and the focus on modern
-				interfaces is not merely a pursuit of technological modernization. It's a strategic move to
-				enhance performance, security, user experience, and future readiness, ensuring that
-				BitTorrent remains a vital part of the internet's infrastructure.
-			</p>
+		<p>
+			In conclusion, the development of new BitTorrent tools in Rust and the focus on modern
+			interfaces is not merely a pursuit of technological modernization. It's a strategic move to
+			enhance performance, security, user experience, and future readiness, ensuring that BitTorrent
+			remains a vital part of the internet's infrastructure.
+		</p>
 
-			<p>
-				You can learn more by reading our blog article <a
-					href="blog/torrust-enhancing-the-bittorrent-ecosystem"
-					>Torrust - Enhancing the BitTorrent Ecosystem</a
-				>.
-			</p>
+		<p>
+			You can learn more by reading our blog article <a
+				href="blog/torrust-enhancing-the-bittorrent-ecosystem"
+				>Torrust - Enhancing the BitTorrent Ecosystem</a
+			>.
+		</p>
 
-			<h2 id="team">The Team</h2>
+		<h2>The Team</h2>
 
-			<p>
-				<a target="_blank" href="https://github.com/torrust">Torrust</a>
-				is an open-source initiative founded by
-				<a href="https://github.com/mickvandijke">@mickvandijke</a>
-				in 2021. It began by forking
-				<a target="_blank" href="https://github.com/naim94a">@naim94a</a>’s UDP tracker project, and
-				including some packages from <a href="https://github.com/greatest-ape">@greatest-ape</a>’s
-				<a target="_blank" href="https://github.com/greatest-ape/aquatic">Aquatic</a>
-				repo. Since 2012, <a target="_blank" href="https://github.com/naim94a">@naim94a</a>
-				had been advancing the tracker. In August 2022,
-				<a target="_blank" href="https://nautilus-cyberneering.de"> Nautilus Cyberneering</a> joined
-				the project, attracted by the community's interest and its alignment with their goals.
-			</p>
+		<p>
+			<a target="_blank" href="https://github.com/torrust">Torrust</a>
+			is an open-source initiative founded by
+			<a href="https://github.com/mickvandijke">@mickvandijke</a>
+			in 2021. It began by forking
+			<a target="_blank" href="https://github.com/naim94a">@naim94a</a>’s UDP tracker project, and
+			including some packages from <a href="https://github.com/greatest-ape">@greatest-ape</a>’s
+			<a target="_blank" href="https://github.com/greatest-ape/aquatic">Aquatic</a>
+			repo. Since 2012, <a target="_blank" href="https://github.com/naim94a">@naim94a</a>
+			had been advancing the tracker. In August 2022,
+			<a target="_blank" href="https://nautilus-cyberneering.de"> Nautilus Cyberneering</a> joined the
+			project, attracted by the community's interest and its alignment with their goals.
+		</p>
 
-			<p>
-				Over the past two years, Torrust has made considerable strides in becoming a leading
-				solution within the BitTorrent open-source community. Using cutting-edge languages and
-				tools, we've built a modern, reliable tracker and index. With version 3.0.0, we are setting
-				the stage for future web3 projects that require decentralized file-sharing.
-			</p>
+		<p>
+			Over the past two years, Torrust has made considerable strides in becoming a leading solution
+			within the BitTorrent open-source community. Using cutting-edge languages and tools, we've
+			built a modern, reliable tracker and index. With version 3.0.0, we are setting the stage for
+			future web3 projects that require decentralized file-sharing.
+		</p>
 
-			<p>Beyond product development, our efforts include:</p>
-			<ul>
-				<li>Improving BitTorrent documentation</li>
-				<li>Supporting Rust-based BitTorrent projects</li>
-				<li>Participating in protocol discussions</li>
-			</ul>
+		<p>Beyond product development, our efforts include:</p>
+		<ul>
+			<li>Improving BitTorrent documentation</li>
+			<li>Supporting Rust-based BitTorrent projects</li>
+			<li>Participating in protocol discussions</li>
+		</ul>
 
-			and contributing articles to further the ecosystem. In addition to building great software,
-			we’ve focused on fostering a welcoming environment for contributors. Whether it’s a small typo
-			fix or a significant pull request, we ensure a smooth and positive experience. We take pride
-			in our extensive documentation and prompt feedback, making it easy for anyone to get involved.
+		and contributing articles to further the ecosystem. In addition to building great software,
+		we’ve focused on fostering a welcoming environment for contributors. Whether it’s a small typo
+		fix or a significant pull request, we ensure a smooth and positive experience. We take pride in
+		our extensive documentation and prompt feedback, making it easy for anyone to get involved.
 
-			<p>
-				Many people have contributed in the past regularly. In the last months this have been the
-				core development team.
-			</p>
-			<ul>
-				<li><a href="https://github.com/da2ce7">@da2ce7</a></li>
-				<li><a href="https://github.com/cgbosse">@cgbosse</a></li>
-				<li><a href="https://github.com/grmbyrn">@grmbyrn</a></li>
-				<li><a href="https://github.com/mario-nt">@mario-nt</a></li>
-				<li><a href="https://github.com/josecelano">@josecelano</a></li>
-			</ul>
+		<p>
+			Many people have contributed in the past regularly. In the last months this has been the core
+			development team.
+		</p>
+		<ul>
+			<li><a href="https://github.com/da2ce7">@da2ce7</a></li>
+			<li><a href="https://github.com/cgbosse">@cgbosse</a></li>
+			<li><a href="https://github.com/grmbyrn">@grmbyrn</a></li>
+			<li><a href="https://github.com/mario-nt">@mario-nt</a></li>
+			<li><a href="https://github.com/josecelano">@josecelano</a></li>
+		</ul>
 
-			<h2 id="contributors">Contributors</h2>
+		<h2 id="contributors">Contributors</h2>
 
-			<p>We extend our gratitude to:</p>
+		<p>We extend our gratitude to:</p>
 
-			<p></p>
-			<ul>
-				<li><a target="_blank" href="https://github.com/naim94a">@naim94a</a></li>
-				<li><a href="https://github.com/MCM-Mike">@MCM-Mike</a></li>
-				<li><a href="https://github.com/mickvandijke">@mickvandijke</a></li>
-				<li><a href="https://github.com/greatest-ape">@greatest-ape</a></li>
-				<li><a href="https://github.com/Power2All">@Power2All</a></li>
-				<li><a href="https://github.com/hungfnt">@hungfnt</a></li>
-				<li><a href="https://github.com/alexohneander">@alexohneander</a></li>
-				<li><a href="https://github.com/Aimless321">@Aimless321</a></li>
-				<li><a href="https://github.com/Aimless321">@GGLinnk</a></li>
-				<li><a href="https://github.com/makefu">@makefu</a></li>
-				<li><a href="https://github.com/pcarles">@pcarles</a></li>
-				<li><a href="https://github.com/postmeback">@postmeback</a></li>
-				<li><a href="https://github.com/ldpr">@ldpr</a></li>
-				<li><a href="https://github.com/ty5e3a45">@ty5e3a45</a></li>
-			</ul>
+		<p></p>
+		<ul>
+			<li><a target="_blank" href="https://github.com/naim94a">@naim94a</a></li>
+			<li><a href="https://github.com/MCM-Mike">@MCM-Mike</a></li>
+			<li><a href="https://github.com/mickvandijke">@mickvandijke</a></li>
+			<li><a href="https://github.com/greatest-ape">@greatest-ape</a></li>
+			<li><a href="https://github.com/Power2All">@Power2All</a></li>
+			<li><a href="https://github.com/hungfnt">@hungfnt</a></li>
+			<li><a href="https://github.com/alexohneander">@alexohneander</a></li>
+			<li><a href="https://github.com/Aimless321">@Aimless321</a></li>
+			<li><a href="https://github.com/Aimless321">@GGLinnk</a></li>
+			<li><a href="https://github.com/makefu">@makefu</a></li>
+			<li><a href="https://github.com/pcarles">@pcarles</a></li>
+			<li><a href="https://github.com/postmeback">@postmeback</a></li>
+			<li><a href="https://github.com/ldpr">@ldpr</a></li>
+			<li><a href="https://github.com/ty5e3a45">@ty5e3a45</a></li>
+		</ul>
 
-			and all contributors for their invaluable input—whether in coding, opening issues, submitting
-			pull requests, or improving documentation.
+		and all contributors for their invaluable input—whether in coding, opening issues, submitting
+		pull requests, or improving documentation.
 
-			<h2 id="sponsors">Sponsors</h2>
+		<h2>Sponsors</h2>
 
-			<p>
-				<a target="_blank" href="https://nautilus-cyberneering.de"> Nautilus Cyberneering</a> is dedicated
-				to creating new Open Source Ecosystems. They define Open Source Ecosystems as vibrant communities
-				of users and creators who collaboratively develop open source software that is secure, respectful,
-				and adds value for future generations. This approach is what they term Cyberneering. With a focus
-				on software and hardware development within these ecosystems, their aim is to produce technology
-				that adheres to these principles.
-			</p>
+		<p>
+			<a target="_blank" href="https://nautilus-cyberneering.de"> Nautilus Cyberneering</a> is dedicated
+			to creating new Open Source Ecosystems. They define Open Source Ecosystems as vibrant communities
+			of users and creators who collaboratively develop open source software that is secure, respectful,
+			and adds value for future generations. This approach is what they term Cyberneering. With a focus
+			on software and hardware development within these ecosystems, their aim is to produce technology
+			that adheres to these principles.
+		</p>
 
-			<p>
-				Their activities encompass developing open source software with an emphasis on security,
-				community engagement, and long-term value. This includes a commitment to software that
-				respects user privacy and is designed with future generations in mind. Nautilus
-				Cyberneering's approach combines innovation in the cybernetic field with open source
-				philosophy, fostering environments where collaborative development can thrive.
-			</p>
-		</div>
+		<p>
+			Their activities encompass developing open source software with an emphasis on security,
+			community engagement, and long-term value. This includes a commitment to software that
+			respects user privacy and is designed with future generations in mind. Nautilus Cyberneering's
+			approach combines innovation in the cybernetic field with open source philosophy, fostering
+			environments where collaborative development can thrive.
+		</p>
 	</div>
-</div>
+</PagesWrapper>
 
 <style lang="scss">
 	@import '$lib/scss/breakpoints.scss';
 
-	h1,
-	.layout {
-		padding-inline: 1.5rem;
+	.content-preview {
+		flex: 1;
+		word-break: keep-all;
+		padding-top: 2rem;
 	}
 
-	.container {
-		margin: 0 auto;
+	@include for-desktop-up {
+		.content-preview {
+			overflow-y: auto;
+			padding-top: 0rem;
+		}
 	}
 
-	.layout {
+	#toc-builder-preview > h2 {
+		font-size: 1.8rem;
+		font-weight: bold;
+	}
+
+	#toc-builder-preview > h2:not(:first-of-type) {
+		padding-top: 1.5rem;
+	}
+
+	#toc-builder-preview > h3 {
+		font-size: 1.3rem;
+		font-weight: bold;
+		padding-top: 1rem;
+	}
+
+	p {
+		font-size: 1rem;
+		padding-top: 1rem;
+		color: rgba(245, 245, 245, 0.8);
+		word-break: keep-all;
+	}
+
+	a {
+		word-break: keep-all;
+		color: rgba(255, 49, 0, 1);
+	}
+
+	ul {
 		display: flex;
 		flex-direction: column;
-		margin-top: 4rem;
+		list-style-type: disc;
+		margin: 0;
+		padding-left: 1.5rem;
+		word-break: keep-all;
 	}
 
-	.content {
-		margin-top: 2rem;
+	ul li {
+		margin: 0.25rem 0;
+		word-break: keep-all;
 	}
 
-	h1 {
-		padding-top: 64px;
-		font-size: 2.25rem;
-	}
-
-	h2 {
-		padding-top: 0.5rem;
-		font-size: 1.8rem;
+	.content-preview > p,
+	.content-preview > ul,
+	.content-preview > h2,
+	.content-preview > h3 {
+		margin-bottom: 1rem;
 	}
 
 	h2:not(:first-of-type) {
 		padding-top: 1.5rem;
 	}
 
-	h3 {
-		padding-top: 2rem;
-		font-size: 1.3rem;
-	}
-
-	p {
-		font-size: 1rem;
-		padding-top: 1.5rem;
-		color: rgba(245, 245, 245, 0.8);
-	}
-
-	#bitTorrentProtocol {
-		border-top: 1px solid rgba(245, 245, 245, 0.08);
-		margin-top: 48px;
-	}
-
 	img {
 		border-radius: 24px;
-	}
-
-	@include for-tablet-portrait-up {
-		.layout {
-			flex-direction: column;
-		}
-
-		.content {
-			margin-top: 2rem;
-		}
-	}
-
-	@include for-desktop-up {
-		.layout {
-			flex-direction: row;
-			gap: 2rem;
-		}
-
-		.content {
-			width: 75%;
-			margin-top: 0;
-		}
-
-		h1 {
-			padding-top: 8rem;
-		}
 	}
 </style>

--- a/src/routes/(pages)/community/+page.svelte
+++ b/src/routes/(pages)/community/+page.svelte
@@ -1,291 +1,265 @@
 <script lang="ts">
-	import TableOfContents from '$lib/components/atoms/TableOfContents.svelte'; // Adjust the path if needed
-
-	// Array of section objects with display names and IDs
-	let sections = [
-		{
-			name: 'Why Contribute to our Project?',
-			id: 'whyContribute',
-			subsections: [
-				{ name: 'Embrace Rust: a language of choice', id: 'embraceRust' },
-				{ name: 'Prioritizing Code Quality', id: 'codeQuality' },
-				{ name: 'A welcoming community for newcomers', id: 'welcomingCommunity' },
-				{ name: 'Influence the Project’s Future', id: 'influenceDirection' },
-				{ name: 'Join us today', id: 'joinUs' }
-			]
-		},
-		{ name: 'How to contribute?', id: 'howContribute' },
-		{
-			name: 'Torrent Knowledge Base',
-			id: 'knowledgeBase',
-			subsections: [
-				{ name: 'What Are Torrents?', id: 'whatAreTorrents' },
-				{ name: 'What Is a Tracker?', id: 'whatIsTracker' },
-				{ name: 'What Is a Torrent Index?', id: 'whatIsTorrentIndex' },
-				{ name: 'List of projects using BitTorrent', id: 'listOfProjects' }
-			]
-		},
-		{ name: 'Resources', id: 'resources' }
-	];
-
-	let activeSection = '';
+	import Toc from '$lib/components/atoms/Toc.svelte';
+	import PagesWrapper from '$lib/components/atoms/PagesWrapper.svelte';
 </script>
 
-<div class="container">
-	<h1>Community</h1>
-	<div class="layout">
-		<div>
-			<TableOfContents {sections} {activeSection} />
-		</div>
-		<div class="content">
-			<h2 id="whyContribute">Why Contribute to our Project?</h2>
+<PagesWrapper heading="Community">
+	<Toc />
+	<div id="toc-builder-preview" class="content-preview">
+		<h2>Why Contribute to our Project?</h2>
+		<p>
+			At Torrust, we aim to build a decentralized and transparent ecosystem for BitTorrent
+			technology. By contributing to our project, you're joining a passionate community of
+			developers and users who value open-source software, innovation, and collaboration. Whether
+			you're a Rust enthusiast, a BitTorrent advocate, or simply looking to improve your skills,
+			your contributions will help shape the future of this project and the broader file-sharing
+			infrastructure.
+		</p>
 
-			<p>
-				At Torrust, we aim to build a decentralized and transparent ecosystem for BitTorrent
-				technology. By contributing to our project, you're joining a passionate community of
-				developers and users who value open-source software, innovation, and collaboration. Whether
-				you're a Rust enthusiast, a BitTorrent advocate, or simply looking to improve your skills,
-				your contributions will help shape the future of this project and the broader file-sharing
-				infrastructure.
-			</p>
+		<ul class="list">
+			<li>Modern development with Rust</li>
+			<li>Comprehensive and detailed documentation</li>
+			<li>Commitment to high-quality code</li>
+			<li>Extensive test coverage</li>
+			<li>Long-term project sustainability</li>
+			<li>Open to sponsorship opportunities</li>
+		</ul>
 
-			<ul class="list">
-				<li>Modern development with Rust</li>
-				<li>Comprehensive and detailed documentation</li>
-				<li>Commitment to high-quality code</li>
-				<li>Extensive test coverage</li>
-				<li>Long-term project sustainability</li>
-				<li>Open to sponsorship opportunities</li>
-			</ul>
+		<h3>Embrace Rust: a language of choice</h3>
 
-			<h3 id="embraceRust">Embrace Rust: a language of choice</h3>
+		<p>
+			Why Rust? We’ve chosen Rust for its unmatched safety, performance, and reliability. If you
+			share a passion for writing efficient, modern code, you’ll feel right at home here. Our
+			project provides a great platform for Rust developers to innovate and push boundaries.
+		</p>
 
-			<p>
-				Why Rust? We’ve chosen Rust for its unmatched safety, performance, and reliability. If you
-				share a passion for writing efficient, modern code, you’ll feel right at home here. Our
-				project provides a great platform for Rust developers to innovate and push boundaries.
-			</p>
+		<h3>Prioritizing Code Quality</h3>
 
-			<h3 id="codeQuality">Prioritizing Code Quality</h3>
+		<p>
+			We hold ourselves to the highest coding standards. Every contribution undergoes a thorough
+			review process to ensure robustness and maintainability. Rather than rushing new features, we
+			focus on refining existing functionality to ensure long-term stability.
+		</p>
 
-			<p>
-				We hold ourselves to the highest coding standards. Every contribution undergoes a thorough
-				review process to ensure robustness and maintainability. Rather than rushing new features,
-				we focus on refining existing functionality to ensure long-term stability.
-			</p>
+		<p>
+			With a rigorous suite of automated tests, we ensure that our software remains stable and
+			regression-free. Your contributions will help maintain this legacy of quality.
+		</p>
 
-			<p>
-				With a rigorous suite of automated tests, we ensure that our software remains stable and
-				regression-free. Your contributions will help maintain this legacy of quality.
-			</p>
+		<h3>A welcoming community for newcomers</h3>
 
-			<h3 id="welcomingCommunity">A welcoming community for newcomers</h3>
+		<p>
+			We pride ourselves on being inclusive and supportive, especially for those new to open-source
+			contributions. You’ll find a wealth of documentation, clear explanations of concepts, and a
+			community ready to assist you as you get started.
+		</p>
 
-			<p>
-				We pride ourselves on being inclusive and supportive, especially for those new to
-				open-source contributions. You’ll find a wealth of documentation, clear explanations of
-				concepts, and a community ready to assist you as you get started.
-			</p>
+		<p>
+			Whether you’re looking to improve your Rust skills, learn more about open-source development,
+			or share your expertise, we’re here to help you grow.
+		</p>
 
-			<p>
-				Whether you’re looking to improve your Rust skills, learn more about open-source
-				development, or share your expertise, we’re here to help you grow.
-			</p>
+		<h3>Influence the Project’s Future</h3>
 
-			<h3 id="influenceDirection">Influence the Project’s Future</h3>
+		<p>
+			As an open-source project, your feedback, contributions, and ideas are crucial. Whether you're
+			interested in improving our tracker or enhancing the index, you have the opportunity to
+			directly shape the project’s roadmap.
+		</p>
 
-			<p>
-				As an open-source project, your feedback, contributions, and ideas are crucial. Whether
-				you're interested in improving our tracker or enhancing the index, you have the opportunity
-				to directly shape the project’s roadmap.
-			</p>
+		<p>
+			When you contribute, you become a key part of the Torrust community. Together, we’re building
+			software that will leave a lasting impact.
+		</p>
 
-			<p>
-				When you contribute, you become a key part of the Torrust community. Together, we’re
-				building software that will leave a lasting impact.
-			</p>
+		<h3>Join us today</h3>
 
-			<h3 id="joinUs">Join us today</h3>
+		<p>
+			By contributing to our project, you're not just writing code; you're joining a movement
+			dedicated to creating something truly outstanding with Rust. Together, we can build software
+			that's not only powerful and efficient but also accessible and enjoyable for everyone in the
+			open-source community.
+		</p>
 
-			<p>
-				By contributing to our project, you're not just writing code; you're joining a movement
-				dedicated to creating something truly outstanding with Rust. Together, we can build software
-				that's not only powerful and efficient but also accessible and enjoyable for everyone in the
-				open-source community.
-			</p>
+		<h2>How to contribute?</h2>
 
-			<h2 id="howContribute">How to contribute?</h2>
+		<p>
+			There are many ways to get involved with Torrust. Whether you're a seasoned developer or a
+			newcomer, your contributions are welcome. Here are some ways you can contribute:
+		</p>
 
-			<p>
-				There are many ways to get involved with Torrust. Whether you're a seasoned developer or a
-				newcomer, your contributions are welcome. Here are some ways you can contribute:
-			</p>
+		<ul class="list">
+			<li>Submit bug reports</li>
+			<li>Request new features</li>
+			<li>
+				Contribute to the code. Feel free to ask how if you don't find issues suitable for you
+			</li>
+			<li>Review and improve documentation</li>
+			<li>Provide financial support through sponsorship</li>
+			<li>Engage in community discussions</li>
+		</ul>
 
-			<ul class="list">
-				<li>Submit bug reports</li>
-				<li>Request new features</li>
+		<h2>Torrent Knowledge Base</h2>
+
+		<h3>What Are Torrents?</h3>
+
+		<p>
+			A <strong>torrent</strong> is a small file that contains metadata about the files and folders to
+			be shared and information about the network of computers that share these files. It's used with
+			BitTorrent protocol, which enables fast and efficient distribution of large files over the internet
+			by allowing users to connect directly to each other to download and upload portions of the file
+			simultaneously. This decentralized method of sharing files reduces the load on any single server
+			and can lead to faster download speeds for the users involved. Torrents themselves do not contain
+			the actual content being shared, only the information needed to find and download the content from
+			peers in the BitTorrent network.
+		</p>
+
+		<h3>What Is a Tracker?</h3>
+
+		<p>
+			A <strong>BitTorrent tracker</strong> is a server that facilitates communication between peers
+			using the BitTorrent protocol. When you open a torrent file with a BitTorrent client, the tracker
+			is contacted to help find other users who are sharing the same files. It does not store or distribute
+			the content itself but keeps track of the IP addresses of the peers in the swarm (the group of
+			computers involved in sharing a particular file). The tracker responds to requests from clients
+			with a list of peers, allowing them to connect directly to each other to start downloading and
+			uploading pieces of the file. Essentially, the tracker acts as a central hub that enables peers
+			to find each other, significantly improving the efficiency and speed of file distribution.
+		</p>
+
+		<h3>What Is a Torrent Index?</h3>
+
+		<p>
+			A <strong>BitTorrent index</strong> site is a website that lists torrent files for download. These
+			sites serve as search engines or directories for finding specific files or content within the BitTorrent
+			network. Users can search for and download torrent files based on various categories such as movies,
+			music, software, games, and more. Each torrent file listed on an index site contains metadata about
+			the content it represents, such as the file name, size, and the address of the tracker managing
+			the distribution of the content.
+		</p>
+
+		<p>
+			BitTorrent index sites do not host the content files themselves; instead, they provide the
+			torrent files which users can then open with their BitTorrent clients to download the actual
+			content from other peers in the network. These sites play a crucial role in the BitTorrent
+			ecosystem by making it easier for users to find and access content distributed via BitTorrent.
+		</p>
+
+		<h3>List of projects using BitTorrent</h3>
+
+		<ul>
+			<li>WebTorrent:</li>
+			<ul>
 				<li>
-					Contribute to the code. Feel free to ask how if you don't find issues suitable for you
+					<a href="https://webtorrent.io/faq">https://webtorrent.io/faq</a>
 				</li>
-				<li>Review and improve documentation</li>
-				<li>Provide financial support through sponsorship</li>
-				<li>Engage in community discussions</li>
 			</ul>
-
-			<h2 id="knowledgeBase">Torrent Knowledge Base</h2>
-
-			<h3 id="whatAreTorrents">What Are Torrents?</h3>
-
-			<p>
-				A <strong>torrent</strong> is a small file that contains metadata about the files and folders
-				to be shared and information about the network of computers that share these files. It's used
-				with BitTorrent protocol, which enables fast and efficient distribution of large files over the
-				internet by allowing users to connect directly to each other to download and upload portions
-				of the file simultaneously. This decentralized method of sharing files reduces the load on any
-				single server and can lead to faster download speeds for the users involved. Torrents themselves
-				do not contain the actual content being shared, only the information needed to find and download
-				the content from peers in the BitTorrent network.
-			</p>
-
-			<h3 id="whatIsTracker">What Is a Tracker?</h3>
-
-			<p>
-				A <strong>BitTorrent tracker</strong> is a server that facilitates communication between peers
-				using the BitTorrent protocol. When you open a torrent file with a BitTorrent client, the tracker
-				is contacted to help find other users who are sharing the same files. It does not store or distribute
-				the content itself but keeps track of the IP addresses of the peers in the swarm (the group of
-				computers involved in sharing a particular file). The tracker responds to requests from clients
-				with a list of peers, allowing them to connect directly to each other to start downloading and
-				uploading pieces of the file. Essentially, the tracker acts as a central hub that enables peers
-				to find each other, significantly improving the efficiency and speed of file distribution.
-			</p>
-
-			<h3 id="whatIsTorrentIndex">What Is a Torrent Index?</h3>
-
-			<p>
-				A <strong>BitTorrent index</strong> site is a website that lists torrent files for download.
-				These sites serve as search engines or directories for finding specific files or content within
-				the BitTorrent network. Users can search for and download torrent files based on various categories
-				such as movies, music, software, games, and more. Each torrent file listed on an index site contains
-				metadata about the content it represents, such as the file name, size, and the address of the
-				tracker managing the distribution of the content.
-			</p>
-
-			<p>
-				BitTorrent index sites do not host the content files themselves; instead, they provide the
-				torrent files which users can then open with their BitTorrent clients to download the actual
-				content from other peers in the network. These sites play a crucial role in the BitTorrent
-				ecosystem by making it easier for users to find and access content distributed via
-				BitTorrent.
-			</p>
-
-			<h3 id="listOfProjects">List of projects using BitTorrent</h3>
-
+			<li>Others:</li>
 			<ul>
-				<li>WebTorrent:</li>
-				<ul>
-					<li>
-						<a href="https://webtorrent.io/faq">https://webtorrent.io/faq</a>
-					</li>
-				</ul>
-				<li>Others:</li>
-				<ul>
-					<li>
-						<a href="https://github.com/urbanguacamole/torrent-paradise">torrent-paradise</a>
-					</li>
-					<li>
-						<a href="https://academictorrents.com/">https://academictorrents.com/</a>
-					</li>
-					<li>
-						<a href="https://github.com/bigscience-workshop/petals"
-							>https://github.com/bigscience-workshop/petals</a
-						>
-					</li>
-				</ul>
+				<li>
+					<a href="https://github.com/urbanguacamole/torrent-paradise">torrent-paradise</a>
+				</li>
+				<li>
+					<a href="https://academictorrents.com/">https://academictorrents.com/</a>
+				</li>
+				<li>
+					<a href="https://github.com/bigscience-workshop/petals"
+						>https://github.com/bigscience-workshop/petals</a
+					>
+				</li>
 			</ul>
+		</ul>
 
-			<h2 id="resources">Resources</h2>
+		<h2>Resources</h2>
 
+		<ul>
+			<li>Discussions</li>
 			<ul>
-				<li>Discussions</li>
-				<ul>
-					<li>
-						<a href="https://github.com/torrust/torrust-tracker/discussions">Tracker</a>
-						<a href="https://github.com/torrust/torrust-index/discussions">Index</a>
-						<a href="https://github.com/torrust/torrust-index-gui/discussions">Index GUI</a>
-					</li>
-				</ul>
-				<li>Documentation</li>
-				<ul>
-					<li>
-						<a href="https://docs.rs/torrust-tracker/latest/torrust_tracker/">Tracker</a>
-						<a href="https://docs.rs/torrust-index/latest/torrust_tracker/">Index</a>
-						<a href="https://github.com/torrust/torrust-index-gui/tree/develop/docs">Index GUI</a>
-					</li>
-				</ul>
+				<li>
+					<a href="https://github.com/torrust/torrust-tracker/discussions">Tracker</a>
+				</li>
+				<li>
+					<a href="https://github.com/torrust/torrust-index/discussions">Index</a>
+				</li>
+				<li>
+					<a href="https://github.com/torrust/torrust-index-gui/discussions">Index GUI</a>
+				</li>
 			</ul>
-		</div>
+			<li>Documentation</li>
+			<ul>
+				<li>
+					<a href="https://docs.rs/torrust-tracker/latest/torrust_tracker/">Tracker</a>
+				</li>
+				<li>
+					<a href="https://docs.rs/torrust-index/latest/torrust_tracker/">Index</a>
+				</li>
+				<li>
+					<a href="https://github.com/torrust/torrust-index-gui/tree/develop/docs">Index GUI</a>
+				</li>
+			</ul>
+		</ul>
 	</div>
-</div>
+</PagesWrapper>
 
 <style lang="scss">
 	@import '$lib/scss/breakpoints.scss';
 
-	h1,
-	.layout {
-		padding-inline: 1.5rem;
-	}
-
-	.layout {
-		margin-top: 4rem;
-	}
-
-	.content {
-		margin-top: 2rem;
-	}
-
-	h1 {
-		padding-top: 64px;
-		font-size: 2.25rem;
-	}
-
-	h2 {
-		padding-top: 0.5rem;
-		font-size: 1.8rem;
-	}
-
-	h2:not(:first-of-type) {
-		padding-top: 1.5rem; /* Add top padding to all h2 elements except the first one */
-	}
-
-	h3 {
+	.content-preview {
+		flex: 1;
+		word-break: keep-all;
 		padding-top: 2rem;
+	}
+
+	#toc-builder-preview > h2 {
+		font-size: 1.8rem;
+		font-weight: bold;
+	}
+
+	#toc-builder-preview > h2:not(:first-of-type) {
+		padding-top: 1.5rem;
+	}
+
+	#toc-builder-preview > h3 {
 		font-size: 1.3rem;
+		font-weight: bold;
+		padding-top: 1rem;
 	}
 
 	p {
 		font-size: 1rem;
-		padding-top: 1.5rem;
+		padding-top: 1rem;
 		color: rgba(245, 245, 245, 0.8);
 	}
 
+	a {
+		word-break: keep-all;
+		color: rgba(255, 49, 0, 1);
+	}
+
+	ul {
+		display: flex;
+		flex-direction: column;
+		list-style-type: disc;
+		margin: 0;
+		padding-left: 1.5rem;
+	}
+
+	ul li {
+		margin: 0.25rem 0;
+		word-break: keep-all;
+	}
+
+	.content-preview > p,
+	.content-preview > ul,
+	.content-preview > h2,
+	.content-preview > h3 {
+		margin-bottom: 1rem;
+	}
+
 	@include for-desktop-up {
-		.container {
-			margin: 0 auto;
-		}
-
-		h1,
-		.layout {
-			display: flex;
-			gap: 2rem;
-		}
-
-		.content {
-			margin-top: 0rem;
-		}
-
-		h1 {
-			padding-top: 8rem;
+		.content-preview {
+			overflow-y: auto;
+			padding-top: 0rem;
 		}
 	}
 </style>

--- a/src/routes/(pages)/self-host/+page.svelte
+++ b/src/routes/(pages)/self-host/+page.svelte
@@ -1,156 +1,121 @@
 <script lang="ts">
-	import TableOfContents from '$lib/components/atoms/TableOfContents.svelte';
 	import Callout from '$lib/components/molecules/Callout.svelte';
-
-	// Array of section objects with display names and IDs
-	let sections = [
-		{ name: 'Torrent Solution (Index + Tracker)', id: 'torrustSolution' },
-		{ name: 'Torrust Index', id: 'torrustIndex' },
-		{ name: 'Torrust Tracker', id: 'torrustTracker' }
-	];
-
-	let activeSection = '';
+	import PagesWrapper from '$lib/components/atoms/PagesWrapper.svelte';
+	import Toc from '$lib/components/atoms/Toc.svelte';
 </script>
 
-<div class="container">
-	<h1>Self-host</h1>
+<PagesWrapper heading="Self-host">
+	<Toc />
+	<div id="toc-builder-preview" class="content-preview">
+		<h2 id="torrustSolution">Torrust Solution (Index + Tracker)</h2>
 
-	<div class="layout">
-		<div>
-			<TableOfContents {sections} {activeSection} />
-		</div>
+		<p>
+			Considering hosting your own torrent site? Torrust offers a comprehensive solution with both
+			the Torrust <a href="torrent-index">Index</a>
+			and the <a href="torrent-tracker">Tracker</a>.
+		</p>
 
-		<div class="content">
-			<h2 id="torrustSolution">Torrust Solution (Index + Tracker)</h2>
+		<p>
+			The Torrust Tracker is integrated with the Index, ensuring that downloaded torrents
+			automatically include it in their tracker list.
+		</p>
 
-			<p>
-				Considering hosting your own torrent site? Torrust offers a comprehensive solution with both
-				the Torrust <a href="torrent-index">Index</a>
-				and the <a href="torrent-tracker">Tracker</a>.
-			</p>
+		<p>
+			Torrust is highly flexible. You can run both the Tracker and Index together on the same
+			server, or set them up separately. You can choose to build from source or use pre-built
+			containers. If you don't expect heavy traffic, we recommend using Docker Compose to simplify
+			setup. For detailed instructions, refer to our guide on <a
+				href="blog/deploying-torrust-to-production">Deploying Torrust to Production</a
+			>.
+		</p>
 
-			<p>
-				The Torrust Tracker is integrated with the Index, ensuring that downloaded torrents
-				automatically include it in their tracker list.
-			</p>
+		<Callout type="warning">
+			Note: You can install the Tracker independently, but the Index cannot function without the
+			Torrust Tracker.
+		</Callout>
 
-			<p>
-				Torrust is highly flexible. You can run both the Tracker and Index together on the same
-				server, or set them up separately. You can choose to build from source or use pre-built
-				containers. If you don't expect heavy traffic, we recommend using Docker Compose to simplify
-				setup. For detailed instructions, refer to our guide on <a
-					href="blog/deploying-torrust-to-production">Deploying Torrust to Production</a
-				>.
-			</p>
+		<p>
+			Our tutorial demonstrates how to install both the Tracker and Index on a single server using a
+			shared Docker Compose configuration. However, if your deployment requires more resources, you
+			can host the Tracker and Index on separate servers. In that case, modify the Docker Compose
+			setup to split the services, and configure the Index to connect to the external Tracker.
+		</p>
 
-			<Callout type="warning">
-				Note: You can install the Tracker independently, but the Index cannot function without the
-				Torrust Tracker.
-			</Callout>
+		<p>For more information on installation, refer to the following resources:</p>
 
-			<p>
-				Our tutorial demonstrates how to install both the Tracker and Index on a single server using
-				a shared Docker Compose configuration. However, if your deployment requires more resources,
-				you can host the Tracker and Index on separate servers. In that case, modify the Docker
-				Compose setup to split the services, and configure the Index to connect to the external
-				Tracker.
-			</p>
+		<ul>
+			<li>
+				<a href="https://docs.rs/torrust-tracker/latest/torrust_tracker/">Tracker Documentation</a>
+			</li>
+			<li>
+				<a href="https://docs.rs/torrust-tracker/latest/torrust_index/">Index Documentation</a>
+			</li>
+			<li>
+				<a href="https://github.com/torrust/torrust-tracker/blob/develop/docs/containers.md"
+					>Tracker Containerization Guide</a
+				>
+			</li>
+			<li>
+				<a href="https://github.com/torrust/torrust-index/blob/develop/docs/containers.md"
+					>Index Containerization Guide</a
+				>
+			</li>
+			<li>
+				<a href="https://github.com/torrust/torrust-compose">Torrust Compose Repository</a> (Docker Compose
+				setups)
+			</li>
+			<li>
+				<a href="https://github.com/torrust/torrust-demo">Torrust Demo Repository</a> (issues and feedback)
+			</li>
+			<li><a href="http://localhost:5173/tags/Deployment">Deployment Tutorials</a> (blog)</li>
+		</ul>
 
-			<p>For more information on installation, refer to the following resources:</p>
+		<Callout type="info">
+			If you're not familiar with system administration, we recommend using Docker Compose for
+			installation. It simplifies the process and provides automated certificate provisioning and
+			renewal.
+		</Callout>
 
-			<ul>
-				<li>
-					<a href="https://docs.rs/torrust-tracker/latest/torrust_tracker/">Tracker Documentation</a
-					>
-				</li>
-				<li>
-					<a href="https://docs.rs/torrust-tracker/latest/torrust_index/">Index Documentation</a>
-				</li>
-				<li>
-					<a href="https://github.com/torrust/torrust-tracker/blob/develop/docs/containers.md"
-						>Tracker Containerization Guide</a
-					>
-				</li>
-				<li>
-					<a href="https://github.com/torrust/torrust-index/blob/develop/docs/containers.md"
-						>Index Containerization Guide</a
-					>
-				</li>
-				<li>
-					<a href="https://github.com/torrust/torrust-compose">Torrust Compose Repository</a> (Docker
-					Compose setups)
-				</li>
-				<li>
-					<a href="https://github.com/torrust/torrust-demo">Torrust Demo Repository</a> (issues and feedback)
-				</li>
-				<li><a href="http://localhost:5173/tags/Deployment">Deployment Tutorials</a> (blog)</li>
-			</ul>
+		<h2 id="torrustIndex">Torrust Index</h2>
 
-			<Callout type="info">
-				If you're not familiar with system administration, we recommend using Docker Compose for
-				installation. It simplifies the process and provides automated certificate provisioning and
-				renewal.
-			</Callout>
+		<p>
+			For instructions on installing the Index independently, visit the <a
+				href="torrent-index#installation">installation section</a
+			> where you'll find guides for both source-based and Docker installations.
+		</p>
 
-			<h2 id="torrustIndex">Torrust Index</h2>
+		<h2 id="torrustTracker">Torrust Tracker</h2>
 
-			<p>
-				For instructions on installing the Index independently, visit the <a
-					href="torrent-index#installation">installation section</a
-				> where you'll find guides for both source-based and Docker installations.
-			</p>
+		<p>
+			If you choose to install only the Tracker, please refer to the <a
+				href="torrent-tracker#installation">installation section</a
+			> for detailed instructions on building from source or using Docker.
+		</p>
 
-			<h2 id="torrustTracker">Torrust Tracker</h2>
-
-			<p>
-				If you choose to install only the Tracker, please refer to the <a
-					href="torrent-tracker#installation">installation section</a
-				> for detailed instructions on building from source or using Docker.
-			</p>
-
-			<p>
-				If your tracker traffic is high, you might prefer to run the Tracker on a separate server.
-				To do so, simply remove the Tracker service from your Docker Compose configuration (if
-				you're using Docker Compose) and set it up independently using source builds or containers.
-			</p>
-		</div>
+		<p>
+			If your tracker traffic is high, you might prefer to run the Tracker on a separate server. To
+			do so, simply remove the Tracker service from your Docker Compose configuration (if you're
+			using Docker Compose) and set it up independently using source builds or containers.
+		</p>
 	</div>
-</div>
+</PagesWrapper>
 
 <style lang="scss">
 	@import '$lib/scss/breakpoints.scss';
 
-	h1,
-	.layout {
-		padding-inline: 1.5rem;
+	.content-preview {
+		flex: 1;
+		word-break: keep-all;
+		padding-top: 2rem;
 	}
 
-	.layout {
-		margin-top: 4rem;
-	}
-
-	.content {
-		margin-top: 2rem;
-	}
-
-	h1 {
-		padding-top: 64px;
-		font-size: 2.25rem;
-	}
-
-	h2 {
-		padding-top: 0.5rem;
+	#toc-builder-preview > h2 {
 		font-size: 1.8rem;
 	}
 
-	h2:not(:first-of-type) {
-		padding-top: 1.5rem; /* Add top padding to all h2 elements except the first one */
+	#toc-builder-preview > h2:not(:first-of-type) {
+		padding-top: 1.5rem;
 	}
-
-	/*h3 {
-		padding-top: 2rem;
-		font-size: 1.3rem;
-	}*/
 
 	p {
 		font-size: 1rem;
@@ -158,23 +123,15 @@
 		color: rgba(245, 245, 245, 0.8);
 	}
 
+	a {
+		word-break: keep-all;
+		color: rgba(255, 49, 0, 1);
+	}
+
 	@include for-desktop-up {
-		.container {
-			margin: 0 auto;
-		}
-
-		h1,
-		.layout {
-			display: flex;
-			gap: 2rem;
-		}
-
-		.content {
-			margin-top: 0rem;
-		}
-
-		h1 {
-			padding-top: 8rem;
+		.content-preview {
+			overflow-y: auto;
+			padding-top: 0rem;
 		}
 	}
 </style>

--- a/src/routes/(pages)/torrent-index/+page.svelte
+++ b/src/routes/(pages)/torrent-index/+page.svelte
@@ -4,6 +4,7 @@
 	import Table from '$lib/components/atoms/Table.svelte';
 	import Slider from '$lib/components/atoms/Slider.svelte';
 	import Banner from '$lib/components/atoms/Banner.svelte';
+	import TorrustIndexPost from '$lib/components/singletons/TorrustIndexPost.svelte';
 
 	import Sqlite from '$lib/icons/sqlite.svelte';
 	import Rust from '$lib/icons/rust.svelte';
@@ -28,7 +29,6 @@
 		};
 	});
 
-	import TorrustIndexPost from '$lib/components/singletons/TorrustIndexPost.svelte';
 	import {
 		indexTitleArr1,
 		indexBasicTableHeadings,
@@ -137,11 +137,18 @@
 		h2 {
 			margin-top: 4rem;
 			padding-inline: 1.5rem;
+			font-size: 1.8rem;
+			font-weight: bold;
 		}
 
 		p {
 			margin-top: 1.4rem;
 			padding-inline: 1.5rem;
+		}
+
+		a {
+			word-break: keep-all;
+			color: rgba(255, 49, 0, 1);
 		}
 	}
 

--- a/src/routes/(pages)/torrent-tracker/+page.svelte
+++ b/src/routes/(pages)/torrent-tracker/+page.svelte
@@ -4,6 +4,7 @@
 	import Table from '$lib/components/atoms/Table.svelte';
 	import Slider from '$lib/components/atoms/Slider.svelte';
 	import Banner from '$lib/components/atoms/Banner.svelte';
+	import TorrustTrackerPost from '$lib/components/singletons/TorrustTrackerPost.svelte';
 
 	import Sqlite from '$lib/icons/sqlite.svelte';
 	import Rust from '$lib/icons/rust.svelte';
@@ -33,7 +34,6 @@
 		trackerFeaturesTableHeadings,
 		trackerTableData
 	} from '$lib/constants/constants';
-	import TorrustTrackerPost from '$lib/components/singletons/TorrustTrackerPost.svelte';
 </script>
 
 <Banner title={'tracker'} />
@@ -154,11 +154,17 @@
 		h2 {
 			margin-top: 4rem;
 			padding-inline: 1.5rem;
+			font-size: 1.8rem;
+			font-weight: bold;
 		}
 
 		p {
 			margin-top: 1.4rem;
 			padding-inline: 1.5rem;
+		}
+
+		a {
+			word-break: keep-all;
 		}
 	}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '$lib/scss/global.scss';
 	import Header from '$lib/components/organisms/Header.svelte';
 	import Footer from '$lib/components/organisms/Footer.svelte';
+	import '../app.css';
 </script>
 
 <Header />

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -189,6 +189,7 @@
 		display: flex;
 		flex-direction: column;
 		color: rgba(245, 245, 245, 0.96);
+		margin: 0 auto;
 
 		@include for-desktop-up {
 			max-width: 1176px;
@@ -199,6 +200,7 @@
 		text-align: center;
 		color: rgba(245, 245, 245, 0.96);
 		padding-top: 1.5rem;
+		font-size: 1.8rem;
 	}
 
 	.grid {
@@ -206,6 +208,8 @@
 		display: grid;
 		grid-template-columns: 1fr 1fr;
 		grid-gap: 24px;
+		max-width: 1200px; // Set a max width for centering control
+		margin: 0 auto;
 
 		@include for-phone-only {
 			grid-template-columns: 1fr;

--- a/src/routes/blog/contributor-path.md
+++ b/src/routes/blog/contributor-path.md
@@ -236,7 +236,7 @@ They are totally independent from the Index and Tracker. They might be a good wa
 
 In our blog you will find tutorials like:
 
-- [How To Setup The Dev Env](./blog/how-to-setup-the-development-environment)
+- [How To Setup The Dev Env](./how-to-setup-the-development-environment)
 
 You can also open a new discussion or issues in all repos if there is something you would like to contribute with but you are not sure where to start from.
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,6 +5,7 @@ import { mdsvex } from 'mdsvex';
 import rehypeExternalLinks from 'rehype-external-links';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import { preprocessMeltUI, sequence } from '@melt-ui/pp';
 
 const extensions = ['.svelte', '.md'];
 
@@ -17,7 +18,7 @@ const config = {
 			entries: ['*']
 		}
 	},
-	preprocess: [
+	preprocess: sequence([
 		vitePreprocess(),
 		mdsvex({
 			extensions: extensions,
@@ -39,8 +40,9 @@ const config = {
 					}
 				]
 			]
-		})
-	],
+		}),
+		preprocessMeltUI()
+	]),
 	extensions: extensions
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,89 @@
+import type { Config } from 'tailwindcss';
+import plugin from 'tailwindcss/plugin';
+import typography from '@tailwindcss/typography';
+
+export default {
+	content: ['./src/**/*.{html,js,svelte,ts}'],
+
+	theme: {
+		container: {
+			center: true,
+			padding: '2rem',
+			screens: {
+				'2xl': '1440px'
+			}
+		},
+		extend: {
+			colors: {
+				magnum: {
+					'50': '#fff9ed',
+					'100': '#fef2d6',
+					'200': '#fce0ac',
+					'300': '#f9c978',
+					'400': '#f7b155',
+					'500': '#f38d1c',
+					'600': '#e47312',
+					'700': '#bd5711',
+					'800': '#964516',
+					'900': '#793a15',
+					'950': '#411c09'
+				}
+			},
+			fontFamily: {
+				sans: [
+					'-apple-system',
+					'BlinkMacSystemFont',
+					'Segoe UI',
+					'Roboto',
+					'Oxygen',
+					'Ubuntu',
+					'Cantarell',
+					'Fira Sans',
+					'Droid Sans',
+					'Helvetica Neue',
+					'Arial',
+					'sans-serif',
+					'Apple Color Emoji',
+					'Segoe UI Emoji',
+					'Segoe UI Symbol'
+				],
+				mono: [
+					'ui-monospace',
+					'SFMono-Regular',
+					'SF Mono',
+					'Menlo',
+					'Consolas',
+					'Liberation Mono',
+					'monospace'
+				]
+			},
+			typography: (theme) => ({
+				DEFAULT: {
+					css: {
+						code: {
+							position: 'relative',
+							borderRadius: theme('borderRadius.md')
+						}
+					}
+				}
+			})
+		}
+	},
+
+	plugins: [
+		typography,
+		plugin(function ({ addVariant, matchUtilities, theme }) {
+			addVariant('hocus', ['&:hover', '&:focus']);
+			// Square utility
+			matchUtilities(
+				{
+					square: (value) => ({
+						width: value,
+						height: value
+					})
+				},
+				{ values: theme('spacing') }
+			);
+		})
+	]
+} satisfies Config;


### PR DESCRIPTION
* To improve Table of Contents as mentioned [here](https://github.com/torrust/torrust-website/issues/87) and [here](https://github.com/torrust/torrust-website/issues/92), I installed [Melt UI](https://www.melt-ui.com/) to handle the Table of Contents. I implemented it according to the [Melt UI's docs](https://www.melt-ui.com/docs/builders/table-of-contents) for the appropriate parts of each page in `routes/(pages)`.
* Fixed any changes this installation had on other parts of the website.
* Refactored repeated styles used in `routes/(pages)` by extracting into `PagesWrapper.svelte`.
* Extracted table headings and table data from `routes/(pages)/about/+page.svelte` into `constants/constants` to maintain consistency with data used in other tables on the website.