### PR TITLE
add component to display contributors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,6 @@
 				"@iconify/svelte": "^4.0.2",
 				"@melt-ui/pp": "^0.3.2",
 				"@melt-ui/svelte": "^0.86.0",
-				"@skeletonlabs/skeleton": "^2.10.3",
-				"@skeletonlabs/tw-plugin": "^0.4.0",
 				"@sveltejs/adapter-static": "^3.0.1",
 				"@sveltejs/kit": "^2.5.25",
 				"@types/swiper": "^5.4.3",
@@ -1401,29 +1399,6 @@
 			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
 			"integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
 			"license": "MIT"
-		},
-		"node_modules/@skeletonlabs/skeleton": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-2.10.3.tgz",
-			"integrity": "sha512-O1RecF68zEVvZl3GgRS4emqWMUIQLHvTOFoqGOw/2OXCPE06IxUQrHQf2hnxCPxtGZNXY2YX8UNV38l+eH8GNQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"esm-env": "1.0.0"
-			},
-			"peerDependencies": {
-				"svelte": "^3.56.0 || ^4.0.0 || ^5.0.0"
-			}
-		},
-		"node_modules/@skeletonlabs/tw-plugin": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@skeletonlabs/tw-plugin/-/tw-plugin-0.4.0.tgz",
-			"integrity": "sha512-v6Y4deBq9ByRx3kTRGgekhhYkWEYgNNNu8UXOwJngCStB7w8SwmbNFSeHkluxMbgCgMnJyp220EMpw9nj/rEsQ==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"tailwindcss": ">=3.0.0"
-			}
 		},
 		"node_modules/@sveltejs/adapter-static": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,6 @@
 		"@iconify/svelte": "^4.0.2",
 		"@melt-ui/pp": "^0.3.2",
 		"@melt-ui/svelte": "^0.86.0",
-		"@skeletonlabs/skeleton": "^2.10.3",
-		"@skeletonlabs/tw-plugin": "^0.4.0",
 		"@sveltejs/adapter-static": "^3.0.1",
 		"@sveltejs/kit": "^2.5.25",
 		"@types/swiper": "^5.4.3",

--- a/src/lib/components/singletons/Contributors.svelte
+++ b/src/lib/components/singletons/Contributors.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	export let contributors;
+	export let error;
+	import { contributorsList } from '$lib/constants/constants';
 </script>
 
-{#if contributors && contributors.length > 0}
-	<div class="container">
-		<h2>Contributors</h2>
-		<p>Here are the people responsible for creating and maintaining Torrust.</p>
-		<div class="flex">
+<div class="container">
+	<h2>Contributors</h2>
+	<p>Here are the people responsible for creating and maintaining Torrust.</p>
+	<div class="flex">
+		{#if !error && contributors && contributors.length > 0}
 			{#each contributors as contributor}
 				<div>
 					<a href={contributor.html_url} target="_blank" title={contributor.login}>
@@ -14,9 +16,21 @@
 					</a>
 				</div>
 			{/each}
-		</div>
+		{:else}
+			{#each contributorsList as contributor}
+				<div>
+					<a
+						href="https://github.com/{contributor.html_url}"
+						target="_blank"
+						title={contributor.html_url}
+					>
+						<img src={contributor.avatar_url} alt="contributor" />
+					</a>
+				</div>
+			{/each}
+		{/if}
 	</div>
-{/if}
+</div>
 
 <style lang="scss">
 	@import '$lib/scss/breakpoints.scss';

--- a/src/lib/components/singletons/Contributors.svelte
+++ b/src/lib/components/singletons/Contributors.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	export let contributors;
+</script>
+
+{#if contributors && contributors.length > 0}
+	<div class="container">
+		<h2>Contributors</h2>
+		<p>Here are the people responsible for creating and maintaining Torrust.</p>
+		<div class="flex">
+			{#each contributors as contributor}
+				<div>
+					<a href={contributor.html_url} target="_blank" title={contributor.login}>
+						<img src={contributor.avatar_url} alt="contributor" />
+					</a>
+				</div>
+			{/each}
+		</div>
+	</div>
+{/if}
+
+<style lang="scss">
+	@import '$lib/scss/breakpoints.scss';
+
+	.container {
+		margin: 0 auto;
+		max-width: 800px;
+	}
+
+	.flex {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 20px;
+		padding-top: 2rem;
+	}
+
+	h2 {
+		text-align: center;
+		color: rgba(245, 245, 245, 0.96);
+		padding-top: 4rem;
+		font-size: 1.8rem;
+		font-weight: bold;
+	}
+
+	p {
+		color: rgba(245, 245, 245, 0.96);
+		text-align: center;
+		padding-top: 2rem;
+	}
+
+	img {
+		width: 50px;
+		border-radius: 50%;
+	}
+</style>

--- a/src/lib/components/singletons/Contributors.svelte
+++ b/src/lib/components/singletons/Contributors.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	export let contributors;
 	export let error;
-	import { contributorsList } from '$lib/constants/constants';
+	import { defaultContributorsList } from '$lib/constants/constants';
 </script>
 
 <div class="container">
@@ -17,7 +17,7 @@
 				</div>
 			{/each}
 		{:else}
-			{#each contributorsList as contributor}
+			{#each defaultContributorsList as contributor}
 				<div>
 					<a
 						href="https://github.com/{contributor.html_url}"

--- a/src/lib/components/singletons/TorrustIndexPost.svelte
+++ b/src/lib/components/singletons/TorrustIndexPost.svelte
@@ -228,16 +228,10 @@ cd /tmp \
 	@import '$lib/scss/breakpoints.scss';
 
 	.wrapper {
-		display: grid;
-		grid-template-columns: 300px 1fr;
-		gap: 4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
 		position: relative;
-	}
-
-	.wrapper :global(.toc) {
-		position: sticky;
-		top: 4rem;
-		height: min-content;
 	}
 
 	.content-preview {
@@ -288,6 +282,17 @@ cd /tmp \
 	}
 
 	@include for-desktop-up {
+		.wrapper {
+			flex-direction: row;
+			gap: 4rem;
+		}
+
+		.wrapper :global(.toc) {
+			position: sticky;
+			top: 4rem;
+			height: min-content;
+		}
+
 		.content-preview {
 			overflow-y: scroll;
 			scrollbar-width: none;

--- a/src/lib/components/singletons/TorrustTrackerPost.svelte
+++ b/src/lib/components/singletons/TorrustTrackerPost.svelte
@@ -248,16 +248,10 @@ cd /tmp \
 <style lang="scss">
 	@import '$lib/scss/breakpoints.scss';
 	.wrapper {
-		display: grid;
-		grid-template-columns: 300px 1fr;
-		gap: 4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
 		position: relative;
-	}
-
-	.wrapper :global(.toc) {
-		position: sticky;
-		top: 4rem;
-		height: min-content;
 	}
 
 	.content-preview {
@@ -307,6 +301,17 @@ cd /tmp \
 	}
 
 	@include for-desktop-up {
+		.wrapper {
+			flex-direction: row;
+			gap: 4rem;
+		}
+
+		.wrapper :global(.toc) {
+			position: sticky;
+			top: 4rem;
+			height: min-content;
+		}
+
 		.content-preview {
 			overflow-y: scroll;
 			scrollbar-width: none;

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -706,30 +706,3 @@ export const aboutTableData = [
 		ipfs: 'Cryptographic validation of all content'
 	}
 ];
-
-export const repoNames = [
-	'torrust-tracker',
-	'torrust-compose',
-	'torrust-website',
-	'torrust-index',
-	'torrust-index-gui',
-	'torrust-bencode-online',
-	'torrust-demo',
-	'bittorrent-infrastructure-project',
-	'bencode2json',
-	'torrust-installer',
-	'bittorrent-primitives',
-	'json2bencode',
-	'torrust-bencode2json',
-	'torrust-index-api-lib',
-	'torrust-index-types-lib',
-	'torrust-hash2torrent',
-	'torrust-index-gui-user-guide',
-	'containerizing-rust-apps-examples',
-	'torrust-serde-bencode-archive',
-	'torrust-index-archive',
-	'torrust-parse-torrent',
-	'torrents-importer-sample',
-	'torrust-documentation',
-	'torrust-docker'
-];

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -706,3 +706,263 @@ export const aboutTableData = [
 		ipfs: 'Cryptographic validation of all content'
 	}
 ];
+
+export const contributorsList = [
+	{
+		html_url: 'mickvandijke',
+		avatar_url: 'https://avatars.githubusercontent.com/u/12992260?v=4'
+	},
+	{
+		html_url: 'Aimless321',
+		avatar_url: 'https://avatars.githubusercontent.com/u/6079485?v=4'
+	},
+	{
+		html_url: 'da2ce7',
+		avatar_url: 'https://avatars.githubusercontent.com/u/691439?v=4'
+	},
+	{
+		html_url: 'josecelano',
+		avatar_url: 'https://avatars.githubusercontent.com/u/58816?v=4'
+	},
+	{
+		html_url: 'jamiew0w',
+		avatar_url: 'https://avatars.githubusercontent.com/u/8589138?v=4'
+	},
+	{
+		html_url: 'GGLinnk',
+		avatar_url: 'https://avatars.githubusercontent.com/u/22531645?v=4'
+	},
+	{
+		html_url: 'naim94a',
+		avatar_url: 'https://avatars.githubusercontent.com/u/227396?v=4'
+	},
+	{
+		html_url: 'Power2All',
+		avatar_url: 'https://avatars.githubusercontent.com/u/2010549?v=4'
+	},
+	{
+		html_url: 'mario-nt',
+		avatar_url: 'https://avatars.githubusercontent.com/u/141633147?v=4'
+	},
+	{
+		html_url: 'hungfnt',
+		avatar_url: 'https://avatars.githubusercontent.com/u/167511750?v=4'
+	},
+	{
+		html_url: 'pataquets',
+		avatar_url: 'https://avatars.githubusercontent.com/u/1286254?v=4'
+	},
+	{
+		html_url: 'alexohneander',
+		avatar_url: 'https://avatars.githubusercontent.com/u/1469954?v=4'
+	},
+	{
+		html_url: 'Binlogo',
+		avatar_url: 'https://avatars.githubusercontent.com/u/7845507?v=4'
+	},
+	{
+		html_url: 'si14',
+		avatar_url: 'https://avatars.githubusercontent.com/u/316910?v=4'
+	},
+	{
+		html_url: 'makefu',
+		avatar_url: 'https://avatars.githubusercontent.com/u/115218?v=4'
+	},
+	{
+		html_url: 'ShrirangB',
+		avatar_url: 'https://avatars.githubusercontent.com/u/68811459?v=4'
+	},
+	{
+		html_url: 'abstralexis',
+		avatar_url: 'https://avatars.githubusercontent.com/u/107479436?v=4'
+	},
+	{
+		html_url: 'ftsimas',
+		avatar_url: 'https://avatars.githubusercontent.com/u/47324723?v=4'
+	},
+	{
+		html_url: 'Zorlin',
+		avatar_url: 'https://avatars.githubusercontent.com/u/1369772?v=4'
+	},
+	{
+		html_url: 'cgbosse',
+		avatar_url: 'https://avatars.githubusercontent.com/u/15330600?v=4'
+	},
+	{
+		html_url: 'anujkumardarji',
+		avatar_url: 'https://avatars.githubusercontent.com/u/45550546?v=4'
+	},
+	{
+		html_url: 'Wolfremium13',
+		avatar_url: 'https://avatars.githubusercontent.com/u/64548160?v=4'
+	},
+	{
+		html_url: 'danielroe',
+		avatar_url: 'https://avatars.githubusercontent.com/u/28706372?v=4'
+	},
+	{
+		html_url: 'pcarles',
+		avatar_url: 'https://avatars.githubusercontent.com/u/51314945?v=4'
+	},
+	{
+		html_url: 'postmeback',
+		avatar_url: 'https://avatars.githubusercontent.com/u/14862687?v=4'
+	},
+	{
+		html_url: 'Douile',
+		avatar_url: 'https://avatars.githubusercontent.com/u/25043847?v=4'
+	},
+	{
+		html_url: 'hugues31',
+		avatar_url: 'https://avatars.githubusercontent.com/u/19244704?v=4'
+	},
+	{
+		html_url: 'kent-williams',
+		avatar_url: 'https://avatars.githubusercontent.com/u/479648?v=4'
+	},
+	{
+		html_url: 'suhlig',
+		avatar_url: 'https://avatars.githubusercontent.com/u/80507?v=4'
+	},
+	{
+		html_url: 'tecknicaltom',
+		avatar_url: 'https://avatars.githubusercontent.com/u/310024?v=4'
+	},
+	{
+		html_url: 'ihaiker',
+		avatar_url: 'https://avatars.githubusercontent.com/u/6601465?v=4'
+	},
+	{
+		html_url: 'rimathia',
+		avatar_url: 'https://avatars.githubusercontent.com/u/7736877?v=4'
+	},
+	{
+		html_url: 'grmbyrn',
+		avatar_url: 'https://avatars.githubusercontent.com/u/95353365?v=4'
+	},
+	{
+		html_url: 'matfantinel',
+		avatar_url: 'https://avatars.githubusercontent.com/u/24247035?v=4'
+	},
+	{
+		html_url: 'nafumal',
+		avatar_url: 'https://avatars.githubusercontent.com/u/167825698?v=4'
+	},
+	{
+		html_url: 'GGist',
+		avatar_url: 'https://avatars.githubusercontent.com/u/5248583?v=4'
+	},
+	{
+		html_url: 'hauleth',
+		avatar_url: 'https://avatars.githubusercontent.com/u/291639?v=4'
+	},
+	{
+		html_url: 'reeFridge',
+		avatar_url: 'https://avatars.githubusercontent.com/u/12645379?v=4'
+	},
+	{
+		html_url: 'astro',
+		avatar_url: 'https://avatars.githubusercontent.com/u/12923?v=4'
+	},
+	{
+		html_url: 'derekhendrickx',
+		avatar_url: 'https://avatars.githubusercontent.com/u/1218149?v=4'
+	},
+	{
+		html_url: 'morrme',
+		avatar_url: 'https://avatars.githubusercontent.com/u/26514778?v=4'
+	},
+	{
+		html_url: 'chpio',
+		avatar_url: 'https://avatars.githubusercontent.com/u/545659?v=4'
+	},
+	{
+		html_url: 'toby',
+		avatar_url: 'https://avatars.githubusercontent.com/u/83556?v=4'
+	},
+	{
+		html_url: 'madadam',
+		avatar_url: 'https://avatars.githubusercontent.com/u/5271?v=4'
+	},
+	{
+		html_url: '5225225',
+		avatar_url: 'https://avatars.githubusercontent.com/u/8584210?v=4'
+	},
+	{
+		html_url: 'adamhammes',
+		avatar_url: 'https://avatars.githubusercontent.com/u/5597274?v=4'
+	},
+	{
+		html_url: 'casey',
+		avatar_url: 'https://avatars.githubusercontent.com/u/1945?v=4'
+	},
+	{
+		html_url: 'nrempel',
+		avatar_url: 'https://avatars.githubusercontent.com/u/540048?v=4'
+	},
+	{
+		html_url: 'thequux',
+		avatar_url: 'https://avatars.githubusercontent.com/u/5264?v=4'
+	},
+	{
+		html_url: 'letFunny',
+		avatar_url: 'https://avatars.githubusercontent.com/u/24965409?v=4'
+	},
+
+	{
+		html_url: 'svartalf',
+		avatar_url: 'https://avatars.githubusercontent.com/u/1279564?v=4'
+	},
+	{
+		html_url: 'alekitto',
+		avatar_url: 'https://avatars.githubusercontent.com/u/1257206?v=4'
+	},
+	{
+		html_url: 'prateekkumarweb',
+		avatar_url: 'https://avatars.githubusercontent.com/u/15064671?v=4'
+	},
+	{
+		html_url: 'benbrandt',
+		avatar_url: 'https://avatars.githubusercontent.com/u/2111074?v=4'
+	},
+	{
+		html_url: 'Robbepop',
+		avatar_url: 'https://avatars.githubusercontent.com/u/8193155?v=4'
+	},
+	{
+		html_url: 'rye',
+		avatar_url: 'https://avatars.githubusercontent.com/u/1566689?v=4'
+	},
+	{
+		html_url: 'Luni-4',
+		avatar_url: 'https://avatars.githubusercontent.com/u/12353765?v=4'
+	},
+	{
+		html_url: 'qryxip',
+		avatar_url: 'https://avatars.githubusercontent.com/u/14125495?v=4'
+	},
+	{
+		html_url: 'stepankuzmin',
+		avatar_url: 'https://avatars.githubusercontent.com/u/533564?v=4'
+	},
+	{
+		html_url: 'ubnt-intrepid',
+		avatar_url: 'https://avatars.githubusercontent.com/u/7354350?v=4'
+	},
+	{
+		html_url: 'sharksforarms',
+		avatar_url: 'https://avatars.githubusercontent.com/u/10912917?v=4'
+	},
+	{
+		html_url: 'magecnion',
+		avatar_url: 'https://avatars.githubusercontent.com/u/5495235?v=4'
+	},
+	{
+		html_url: 'ty5e3a45',
+		avatar_url: 'https://avatars.githubusercontent.com/u/155493608?v=4'
+	},
+	{
+		html_url: 'TGlide',
+		avatar_url: 'https://avatars.githubusercontent.com/u/26071571?v=4'
+	}
+];

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -706,3 +706,30 @@ export const aboutTableData = [
 		ipfs: 'Cryptographic validation of all content'
 	}
 ];
+
+export const repoNames = [
+	'torrust-tracker',
+	'torrust-compose',
+	'torrust-website',
+	'torrust-index',
+	'torrust-index-gui',
+	'torrust-bencode-online',
+	'torrust-demo',
+	'bittorrent-infrastructure-project',
+	'bencode2json',
+	'torrust-installer',
+	'bittorrent-primitives',
+	'json2bencode',
+	'torrust-bencode2json',
+	'torrust-index-api-lib',
+	'torrust-index-types-lib',
+	'torrust-hash2torrent',
+	'torrust-index-gui-user-guide',
+	'containerizing-rust-apps-examples',
+	'torrust-serde-bencode-archive',
+	'torrust-index-archive',
+	'torrust-parse-torrent',
+	'torrents-importer-sample',
+	'torrust-documentation',
+	'torrust-docker'
+];

--- a/src/lib/constants/constants.ts
+++ b/src/lib/constants/constants.ts
@@ -707,7 +707,7 @@ export const aboutTableData = [
 	}
 ];
 
-export const contributorsList = [
+export const defaultContributorsList = [
 	{
 		html_url: 'mickvandijke',
 		avatar_url: 'https://avatars.githubusercontent.com/u/12992260?v=4'

--- a/src/lib/stores/contributorsStore.ts
+++ b/src/lib/stores/contributorsStore.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const contributorsStore = writable([]);

--- a/src/lib/utils/cache.ts
+++ b/src/lib/utils/cache.ts
@@ -4,6 +4,7 @@ import type { CacheEntry } from '$lib/utils/types';
 export const contributorsStore = writable<Map<string, CacheEntry<unknown>>>(new Map());
 
 const CACHE_TTL = 60 * 60 * 1000;
+const token = import.meta.env.VITE_GITHUB_TOKEN;
 
 export async function fetchWithCache<T>(url: string): Promise<T> {
 	const now = Date.now();
@@ -12,28 +13,14 @@ export async function fetchWithCache<T>(url: string): Promise<T> {
 
 	const cached = cache.get(url);
 	if (cached && cached.expiresAt > now) {
-		console.log('Fetching data from store');
 		return cached.data as T;
 	}
 
-	console.log('Fetching data from API');
-
-	const response = await fetch(url);
-
-	const rateLimit = response.headers.get('X-RateLimit-Limit');
-	const rateRemaining = response.headers.get('X-RateLimit-Remaining');
-	const resetTime = response.headers.get('X-RateLimit-Reset');
-
-	if (rateLimit && rateRemaining) {
-		console.log(
-			`Rate limit: ${rateLimit}, Remaining: ${rateRemaining} ${new Date(Date.now()).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
-		);
-	}
-
-	if (resetTime) {
-		const resetDate = new Date(parseInt(resetTime) * 1000);
-		console.log(`Rate limit resets at: ${resetDate}`);
-	}
+	const response = await fetch(url, {
+		headers: {
+			Authorization: `Bearer ${token}`
+		}
+	});
 
 	if (!response.ok) {
 		console.error(`Failed to fetch from ${url}:`, response.statusText);

--- a/src/lib/utils/cache.ts
+++ b/src/lib/utils/cache.ts
@@ -1,0 +1,51 @@
+import { writable, get } from 'svelte/store';
+import type { CacheEntry } from '$lib/utils/types';
+
+export const contributorsStore = writable<Map<string, CacheEntry<unknown>>>(new Map());
+
+const CACHE_TTL = 60 * 60 * 1000;
+
+export async function fetchWithCache<T>(url: string): Promise<T> {
+	const now = Date.now();
+
+	const cache = get(contributorsStore);
+
+	const cached = cache.get(url);
+	if (cached && cached.expiresAt > now) {
+		console.log('Fetching data from store');
+		return cached.data as T;
+	}
+
+	console.log('Fetching data from API');
+
+	const response = await fetch(url);
+
+	const rateLimit = response.headers.get('X-RateLimit-Limit');
+	const rateRemaining = response.headers.get('X-RateLimit-Remaining');
+	const resetTime = response.headers.get('X-RateLimit-Reset');
+
+	if (rateLimit && rateRemaining) {
+		console.log(
+			`Rate limit: ${rateLimit}, Remaining: ${rateRemaining} ${new Date(Date.now()).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+		);
+	}
+
+	if (resetTime) {
+		const resetDate = new Date(parseInt(resetTime) * 1000);
+		console.log(`Rate limit resets at: ${resetDate}`);
+	}
+
+	if (!response.ok) {
+		console.error(`Failed to fetch from ${url}:`, response.statusText);
+		throw new Error(`Failed to fetch from ${url}`);
+	}
+
+	const data = await response.json();
+
+	contributorsStore.update((currentCache) => {
+		currentCache.set(url, { data, expiresAt: now + CACHE_TTL });
+		return new Map(currentCache);
+	});
+
+	return data;
+}

--- a/src/lib/utils/cache.ts
+++ b/src/lib/utils/cache.ts
@@ -4,7 +4,6 @@ import type { CacheEntry } from '$lib/utils/types';
 export const contributorsStore = writable<Map<string, CacheEntry<unknown>>>(new Map());
 
 const CACHE_TTL = 60 * 60 * 1000;
-const token = import.meta.env.VITE_GITHUB_TOKEN;
 
 export async function fetchWithCache<T>(url: string): Promise<T> {
 	const now = Date.now();
@@ -16,11 +15,7 @@ export async function fetchWithCache<T>(url: string): Promise<T> {
 		return cached.data as T;
 	}
 
-	const response = await fetch(url, {
-		headers: {
-			Authorization: `Bearer ${token}`
-		}
-	});
+	const response = await fetch(url);
 
 	if (!response.ok) {
 		console.error(`Failed to fetch from ${url}:`, response.statusText);

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -33,6 +33,11 @@ export type Contributor = {
 	html_url: string;
 };
 
+export type CacheEntry<T> = {
+	data: T;
+	expiresAt: number;
+};
+
 export type BlogPost = {
 	tags: string[];
 	keywords: string[];

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -27,6 +27,12 @@ export type Feature = {
 	tags: TagType[];
 };
 
+export type Contributor = {
+	login: string;
+	avatar_url: string;
+	html_url: string;
+};
+
 export type BlogPost = {
 	tags: string[];
 	keywords: string[];

--- a/src/routes/(home)/+page.server.ts
+++ b/src/routes/(home)/+page.server.ts
@@ -1,24 +1,8 @@
-import features from '$lib/data/features';
 import { fetchMarkdownPosts } from '$lib/utils/index_posts';
 import type { Contributor } from '$lib/utils/types';
+import { fetchWithCache } from '$lib/utils/cache';
 
-const GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN;
 const BASE_URL = 'https://api.github.com';
-
-async function fetchWithAuth(url: string) {
-	const response = await fetch(url, {
-		headers: {
-			Authorization: `Bearer ${GITHUB_TOKEN}`
-		}
-	});
-
-	if (!response.ok) {
-		console.error(`Failed to fetch from ${url}:`, response.statusText);
-		throw new Error(`Failed to fetch from ${url}`);
-	}
-
-	return response.json();
-}
 
 export async function load() {
 	const allPosts = await fetchMarkdownPosts();
@@ -26,12 +10,12 @@ export async function load() {
 		.sort((a, b) => new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime())
 		.slice(0, 6);
 
-	const repos = await fetchWithAuth(`${BASE_URL}/orgs/torrust/repos`);
+	const repos = await fetchWithCache<{ name: string }[]>(`${BASE_URL}/orgs/torrust/repos`);
 	const gitHubRepos = repos.map((repo: { name: string }) => repo.name);
 
 	const contributorResponses = await Promise.all(
 		gitHubRepos.map((repo: string) =>
-			fetchWithAuth(`${BASE_URL}/repos/torrust/${repo}/contributors`)
+			fetchWithCache<Contributor[]>(`${BASE_URL}/repos/torrust/${repo}/contributors`)
 		)
 	);
 
@@ -41,7 +25,6 @@ export async function load() {
 	);
 
 	return {
-		features,
 		posts,
 		allContributors: uniqueContributors
 	};

--- a/src/routes/(home)/+page.server.ts
+++ b/src/routes/(home)/+page.server.ts
@@ -2,45 +2,40 @@ import features from '$lib/data/features';
 import { fetchMarkdownPosts } from '$lib/utils/index_posts';
 import type { Contributor } from '$lib/utils/types';
 
+const GITHUB_TOKEN = import.meta.env.VITE_GITHUB_TOKEN;
+const BASE_URL = 'https://api.github.com';
+
+async function fetchWithAuth(url: string) {
+	const response = await fetch(url, {
+		headers: {
+			Authorization: `Bearer ${GITHUB_TOKEN}`
+		}
+	});
+
+	if (!response.ok) {
+		console.error(`Failed to fetch from ${url}:`, response.statusText);
+		throw new Error(`Failed to fetch from ${url}`);
+	}
+
+	return response.json();
+}
+
 export async function load() {
 	const allPosts = await fetchMarkdownPosts();
-
 	const posts = allPosts
 		.sort((a, b) => new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime())
 		.slice(0, 6);
 
-	const orgReposURL = 'https://api.github.com/orgs/torrust/repos';
-	const baseURL = 'https://api.github.com/repos/torrust/';
-	const token = import.meta.env.VITE_GITHUB_TOKEN;
-
-	const repoResponse = await fetch(orgReposURL, {
-		headers: {
-			Authorization: `Bearer ${token}`
-		}
-	});
-
-	if (!repoResponse.ok) {
-		console.error('Failed to fetch repositories:', repoResponse.statusText);
-		throw new Error('Failed to fetch repositories');
-	}
-
-	const repos: { name: string }[] = await repoResponse.json();
-
-	const gitHubRepos: string[] = repos.map((repo: { name: string }) => repo.name);
-
-	const urls: string[] = gitHubRepos.map((repo) => `${baseURL}${repo}/contributors`);
+	const repos = await fetchWithAuth(`${BASE_URL}/orgs/torrust/repos`);
+	const gitHubRepos = repos.map((repo: { name: string }) => repo.name);
 
 	const contributorResponses = await Promise.all(
-		urls.map((url) =>
-			fetch(url, {
-				headers: {
-					Authorization: `Bearer ${token}`
-				}
-			}).then((res) => res.json())
+		gitHubRepos.map((repo: string) =>
+			fetchWithAuth(`${BASE_URL}/repos/torrust/${repo}/contributors`)
 		)
 	);
 
-	const allContributors: Contributor[] = [].concat(...contributorResponses);
+	const allContributors: Contributor[] = contributorResponses.flat();
 	const uniqueContributors = Array.from(
 		new Map(allContributors.map((contributor) => [contributor.login, contributor])).values()
 	);

--- a/src/routes/(home)/+page.server.ts
+++ b/src/routes/(home)/+page.server.ts
@@ -14,19 +14,19 @@ export async function load() {
 	const token = import.meta.env.VITE_GITHUB_TOKEN;
 
 	const repoResponse = await fetch(orgReposURL, {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    });
+		headers: {
+			Authorization: `Bearer ${token}`
+		}
+	});
 
-    if (!repoResponse.ok) {
-        console.error('Failed to fetch repositories:', repoResponse.statusText);
-        throw new Error('Failed to fetch repositories');
-    }
+	if (!repoResponse.ok) {
+		console.error('Failed to fetch repositories:', repoResponse.statusText);
+		throw new Error('Failed to fetch repositories');
+	}
 
-    const repos: {name: string}[] = await repoResponse.json();
+	const repos: { name: string }[] = await repoResponse.json();
 
-    const gitHubRepos: string[] = repos.map((repo: { name: string }) => repo.name);
+	const gitHubRepos: string[] = repos.map((repo: { name: string }) => repo.name);
 
 	const urls: string[] = gitHubRepos.map((repo) => `${baseURL}${repo}/contributors`);
 
@@ -48,6 +48,6 @@ export async function load() {
 	return {
 		features,
 		posts,
-		allContributors: uniqueContributors,
+		allContributors: uniqueContributors
 	};
 }

--- a/src/routes/(home)/+page.server.ts
+++ b/src/routes/(home)/+page.server.ts
@@ -1,15 +1,41 @@
+// src/routes/{page}/+page.js (e.g., src/routes/index/+page.js)
 import features from '$lib/data/features';
 import { fetchMarkdownPosts } from '$lib/utils/index_posts';
+import type { Contributor } from '$lib/utils/types';
+import { repoNames } from '$lib/constants/constants';
 
 export async function load() {
+	// Fetch all posts at build time
 	const allPosts = await fetchMarkdownPosts();
 
+	// Get the first 6 posts, sorted by date
 	const posts = allPosts
 		.sort((a, b) => new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime())
 		.slice(0, 6);
 
+	// Fetch contributors data at build time
+	const baseURL = 'https://api.github.com/repos/torrust/';
+	const token = import.meta.env.VITE_GITHUB_TOKEN;
+	const urls = repoNames.map((repo) => `${baseURL}${repo}/contributors`);
+
+	const contributorResponses = await Promise.all(
+		urls.map((url) =>
+			fetch(url, {
+				headers: {
+					Authorization: `Bearer ${token}`
+				}
+			}).then((res) => res.json())
+		)
+	);
+
+	const allContributors: Contributor[] = [].concat(...contributorResponses);
+	const uniqueContributors = Array.from(
+		new Map(allContributors.map((contributor) => [contributor.login, contributor])).values()
+	);
+
 	return {
 		features,
-		posts
+		posts,
+		allContributors: uniqueContributors
 	};
 }

--- a/src/routes/(home)/+page.server.ts
+++ b/src/routes/(home)/+page.server.ts
@@ -1,19 +1,15 @@
-// src/routes/{page}/+page.js (e.g., src/routes/index/+page.js)
 import features from '$lib/data/features';
 import { fetchMarkdownPosts } from '$lib/utils/index_posts';
 import type { Contributor } from '$lib/utils/types';
 import { repoNames } from '$lib/constants/constants';
 
 export async function load() {
-	// Fetch all posts at build time
 	const allPosts = await fetchMarkdownPosts();
 
-	// Get the first 6 posts, sorted by date
 	const posts = allPosts
 		.sort((a, b) => new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime())
 		.slice(0, 6);
 
-	// Fetch contributors data at build time
 	const baseURL = 'https://api.github.com/repos/torrust/';
 	const token = import.meta.env.VITE_GITHUB_TOKEN;
 	const urls = repoNames.map((repo) => `${baseURL}${repo}/contributors`);

--- a/src/routes/(home)/+page.server.ts
+++ b/src/routes/(home)/+page.server.ts
@@ -5,27 +5,38 @@ import { fetchWithCache } from '$lib/utils/cache';
 const BASE_URL = 'https://api.github.com';
 
 export async function load() {
-	const allPosts = await fetchMarkdownPosts();
-	const posts = allPosts
-		.sort((a, b) => new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime())
-		.slice(0, 6);
+	try {
+		const allPosts = await fetchMarkdownPosts();
+		const posts = allPosts
+			.sort((a, b) => new Date(b.meta.date).getTime() - new Date(a.meta.date).getTime())
+			.slice(0, 6);
 
-	const repos = await fetchWithCache<{ name: string }[]>(`${BASE_URL}/orgs/torrust/repos`);
-	const gitHubRepos = repos.map((repo: { name: string }) => repo.name);
+		const repos = await fetchWithCache<{ name: string }[]>(`${BASE_URL}/orgs/torrust/repos`);
+		const gitHubRepos = repos.map((repo: { name: string }) => repo.name);
 
-	const contributorResponses = await Promise.all(
-		gitHubRepos.map((repo: string) =>
-			fetchWithCache<Contributor[]>(`${BASE_URL}/repos/torrust/${repo}/contributors`)
-		)
-	);
+		const contributorResponses = await Promise.all(
+			gitHubRepos.map((repo: string) =>
+				fetchWithCache<Contributor[]>(`${BASE_URL}/repos/torrust/${repo}/contributors`)
+			)
+		);
 
-	const allContributors: Contributor[] = contributorResponses.flat();
-	const uniqueContributors = Array.from(
-		new Map(allContributors.map((contributor) => [contributor.login, contributor])).values()
-	);
+		const allContributors: Contributor[] = contributorResponses.flat();
+		const uniqueContributors = Array.from(
+			new Map(allContributors.map((contributor) => [contributor.login, contributor])).values()
+		);
 
-	return {
-		posts,
-		allContributors: uniqueContributors
-	};
+		return {
+			posts,
+			allContributors: uniqueContributors,
+			error: null
+		};
+	} catch (error) {
+		console.error('Failed to load contributors: ', error);
+
+		return {
+			posts: [],
+			allContributors: [],
+			error: 'Failed to fetch contributors. You may have hit the rate limit.'
+		};
+	}
 }

--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -8,15 +8,21 @@
 	export let data: {
 		posts: BlogPost[];
 		allContributors: Contributor[];
-		gitHubRepos: string[];
 	};
 
 	let filteredPosts = data.posts;
+	let showContributors = true; // A state to control visibility of Contributors component
+	let errorMessage = '';
 </script>
 
 <Hero />
 <WhyContribute />
-<Contributors contributors={data.allContributors} />
+
+{#if showContributors}
+	<Contributors contributors={data.allContributors} />
+{:else}
+	<p>{errorMessage}</p>
+{/if}
 
 {#if filteredPosts && filteredPosts.length > 0}
 	<div class="container">

--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -2,10 +2,12 @@
 	import Hero from '$lib/components/organisms/Hero.svelte';
 	import WhyContribute from '$lib/components/singletons/WhyContribute.svelte';
 	import BlogPreview from '$lib/components/molecules/BlogPreview.svelte';
-	import type { BlogPost } from '$lib/utils/types';
+	import Contributors from '$lib/components/singletons/Contributors.svelte';
+	import type { BlogPost, Contributor } from '$lib/utils/types';
 
 	export let data: {
 		posts: BlogPost[];
+		allContributors: Contributor[];
 	};
 
 	let filteredPosts = data.posts;
@@ -13,7 +15,9 @@
 
 <Hero />
 <WhyContribute />
-{#if filteredPosts && filteredPosts.length}
+<Contributors contributors={data.allContributors} />
+
+{#if filteredPosts && filteredPosts.length > 0}
 	<div class="container">
 		<h2>Latest articles</h2>
 		<div class="grid">

--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -8,21 +8,16 @@
 	export let data: {
 		posts: BlogPost[];
 		allContributors: Contributor[];
+		error: string | null;
 	};
 
 	let filteredPosts = data.posts;
-	let showContributors = true; // A state to control visibility of Contributors component
-	let errorMessage = '';
 </script>
 
 <Hero />
 <WhyContribute />
 
-{#if showContributors}
-	<Contributors contributors={data.allContributors} />
-{:else}
-	<p>{errorMessage}</p>
-{/if}
+<Contributors contributors={data.allContributors} error={data.error} />
 
 {#if filteredPosts && filteredPosts.length > 0}
 	<div class="container">

--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -8,6 +8,7 @@
 	export let data: {
 		posts: BlogPost[];
 		allContributors: Contributor[];
+		gitHubRepos: string[];
 	};
 
 	let filteredPosts = data.posts;
@@ -40,7 +41,7 @@
 		min-height: 100vh;
 		display: flex;
 		flex-direction: column;
-		padding-top: 3rem;
+		padding-top: rem;
 		background: rgba(26, 26, 26, 1);
 		color: rgba(245, 245, 245, 0.96);
 		padding-bottom: 64px;

--- a/src/routes/(pages)/about/+page.svelte
+++ b/src/routes/(pages)/about/+page.svelte
@@ -336,16 +336,10 @@
 	@import '$lib/scss/breakpoints.scss';
 
 	.wrapper {
-		display: grid;
-		grid-template-columns: 300px 1fr;
-		gap: 4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
 		position: relative;
-	}
-
-	.wrapper :global(.toc) {
-		position: sticky;
-		top: 4rem;
-		height: min-content;
 	}
 
 	.content-preview {
@@ -411,6 +405,17 @@
 	}
 
 	@include for-desktop-up {
+		.wrapper {
+			flex-direction: row;
+			gap: 4rem;
+		}
+
+		.wrapper :global(.toc) {
+			position: sticky;
+			top: 4rem;
+			height: min-content;
+		}
+
 		.content-preview {
 			overflow-y: auto;
 			padding-top: 0rem;

--- a/src/routes/(pages)/community/+page.svelte
+++ b/src/routes/(pages)/community/+page.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
 	import Toc from '$lib/components/atoms/Toc.svelte';
 	import PagesWrapper from '$lib/components/atoms/PagesWrapper.svelte';
+	import Contributors from '$lib/components/singletons/Contributors.svelte';
+	import type { Contributor } from '$lib/utils/types';
+
+	export let data: {
+		allContributors: Contributor[];
+		error: string | null;
+	};
 </script>
 
 <PagesWrapper heading="Community">
@@ -203,6 +210,7 @@
 		</div>
 	</div>
 </PagesWrapper>
+<Contributors contributors={data.allContributors} error={data.error} />
 
 <style lang="scss">
 	@import '$lib/scss/breakpoints.scss';

--- a/src/routes/(pages)/community/+page.svelte
+++ b/src/routes/(pages)/community/+page.svelte
@@ -208,16 +208,10 @@
 	@import '$lib/scss/breakpoints.scss';
 
 	.wrapper {
-		display: grid;
-		grid-template-columns: 300px 1fr;
-		gap: 4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
 		position: relative;
-	}
-
-	.wrapper :global(.toc) {
-		position: sticky;
-		top: 4rem;
-		height: min-content;
 	}
 
 	.content-preview {
@@ -274,6 +268,17 @@
 	}
 
 	@include for-desktop-up {
+		.wrapper {
+			flex-direction: row;
+			gap: 4rem;
+		}
+
+		.wrapper :global(.toc) {
+			position: sticky;
+			top: 4rem;
+			height: min-content;
+		}
+
 		.content-preview {
 			overflow-y: scroll;
 			scrollbar-width: none;

--- a/src/routes/(pages)/self-host/+page.svelte
+++ b/src/routes/(pages)/self-host/+page.svelte
@@ -108,16 +108,10 @@
 	@import '$lib/scss/breakpoints.scss';
 
 	.wrapper {
-		display: grid;
-		grid-template-columns: 300px 1fr;
-		gap: 4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
 		position: relative;
-	}
-
-	.wrapper :global(.toc) {
-		position: sticky;
-		top: 4rem;
-		height: min-content;
 	}
 
 	.content-preview {
@@ -160,6 +154,17 @@
 	}
 
 	@include for-desktop-up {
+		.wrapper {
+			flex-direction: row;
+			gap: 4rem;
+		}
+
+		.wrapper :global(.toc) {
+			position: sticky;
+			top: 4rem;
+			height: min-content;
+		}
+
 		.content-preview {
 			overflow-y: scroll;
 			scrollbar-width: none;

--- a/src/routes/blog/contributor-path.md
+++ b/src/routes/blog/contributor-path.md
@@ -27,7 +27,7 @@ hidden: false
     { name: "Introduction", id: "introduction" },
     { name: "Minimum Requirements", id: "minimum-requirements" },
     { name: "Why Getting Started Can Be Challenging", id: "why-getting-started-can-be-challenging" },
-    { name: "How Can You contribute", id: "how-can-you-contribute" },
+    { name: "How You Can Contribute", id: "how-you-can-contribute" },
     { name: "More Resources", id: "more-resources" },
   ]
 
@@ -97,7 +97,7 @@ Our current package structure for the Tracker could be improved in terms of perf
 
 We believe smaller and independent packages will make it easier for contributors to work on specific components without needing to understand the entire codebase.
 
-## How Can You contribute
+## How You Can Contribute
 
 There are many ways to contribute to Torrust, including:
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,9 +3,7 @@ import plugin from 'tailwindcss/plugin';
 import typography from '@tailwindcss/typography';
 
 export default {
-	content: [
-		'./src/**/*.{html,js,svelte,ts}'
-	],
+	content: ['./src/**/*.{html,js,svelte,ts}'],
 
 	theme: {
 		container: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,13 +1,10 @@
 import type { Config } from 'tailwindcss';
 import plugin from 'tailwindcss/plugin';
 import typography from '@tailwindcss/typography';
-import { skeleton } from '@skeletonlabs/tw-plugin';
-import { join } from 'path';
 
 export default {
 	content: [
-		'./src/**/*.{html,js,svelte,ts}',
-		join(require.resolve('@skeletonlabs/skeleton'), '../**/*.{html,js,svelte,ts}')
+		'./src/**/*.{html,js,svelte,ts}'
 	],
 
 	theme: {
@@ -76,7 +73,6 @@ export default {
 	},
 
 	plugins: [
-		skeleton,
 		typography,
 		plugin(function ({ addVariant, matchUtilities, theme }) {
 			addVariant('hocus', ['&:hover', '&:focus']);


### PR DESCRIPTION
* in `routes/(home)/+page.server.ts`, fetch contributors data from GitHub API to use in Torrust repos.
  * Create a `Contributor` type for data coming from GitHub API and store it in `'$lib/utils/types'` to be imported
  * Create an array of repo names and store it in `'$lib/constants/constants'` to be imported and reactively mapped over together with a baseURL
  * Create a Personal Access Token, store it in `.env` and store it in `	const token = import.meta.env.VITE_GITHUB_TOKEN;` to order to increase GitHub API rate limits.
  * Fetch contributor data from multiple GitHub repository URLs concurrently using Promise.all. It sends authenticated GET requests (with a token in the headers) to each URL and parses the JSON response for all the requests.
  * Flatten the array of contributor arrays into a single array of all contributors.
  * Remove duplicate contributors from the all contributors array.
  * Pass array into `routes/(home)/+page.svelte`, which passes it into component `Contributors.svelte` in order to loop over and display each contributor on the home page.

* On each of the `(pages)` routes there wasn't responsiveness to make Table of Contents appear above the text on smaller screens and to the left on wider screens, so I added that to each.