### PR TITLE
chore: upgrade @iconify/svelte v4 → v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@fontsource-variable/roboto-mono": "^5.2.8",
 				"@fontsource-variable/roboto-slab": "^5.2.8",
-				"@iconify/svelte": "^4.2.0",
+				"@iconify/svelte": "^5.2.1",
 				"@tailwindcss/container-queries": "^0.1.1",
 				"@tailwindcss/forms": "^0.5.11",
 				"@tailwindcss/typography": "^0.5.19",
@@ -885,9 +885,9 @@
 			}
 		},
 		"node_modules/@iconify/svelte": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-4.2.0.tgz",
-			"integrity": "sha512-fEl0T7SAPonK7xk6xUlRPDmFDZVDe2Z7ZstlqeDS/sS8ve2uyU+Qa8rTWbIqzZJlRvONkK5kVXiUf9nIc+6OOQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-5.2.1.tgz",
+			"integrity": "sha512-zHmsIPmnIhGd5gc95bNN5FL+GifwMZv7M2rlZEpa7IXYGFJm/XGHdWf6PWQa6OBoC+R69WyiPO9NAj5wjfjbow==",
 			"license": "MIT",
 			"dependencies": {
 				"@iconify/types": "^2.0.0"
@@ -896,7 +896,7 @@
 				"url": "https://github.com/sponsors/cyberalien"
 			},
 			"peerDependencies": {
-				"svelte": ">4.0.0"
+				"svelte": ">5.0.0"
 			}
 		},
 		"node_modules/@iconify/types": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	"dependencies": {
 		"@fontsource-variable/roboto-mono": "^5.2.8",
 		"@fontsource-variable/roboto-slab": "^5.2.8",
-		"@iconify/svelte": "^4.2.0",
+		"@iconify/svelte": "^5.2.1",
 		"@tailwindcss/container-queries": "^0.1.1",
 		"@tailwindcss/forms": "^0.5.11",
 		"@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
## Overview

Upgrades `@iconify/svelte` from **v4.2.0** to **v5.2.1**.

Part of epic #174.

Closes #172

## Changes

- `package.json`: `@iconify/svelte` `^4.2.0` → `^5.2.1`
- `package-lock.json`: updated lockfile

## What's new in v5

- Updated for Svelte 5 runes compatibility
- Uses `<script module>` syntax in the component
- Component API (`icon`, `color`, `width`, `height` props) is **backward-compatible** — no usage changes required

## Components using `@iconify/svelte` (all unchanged)

- `src/lib/components/atoms/Slider.svelte`
- `src/lib/components/molecules/CodeBlock.svelte`
- `src/lib/components/singletons/SearchBar.svelte`
- `src/lib/components/singletons/PrevNextPost.svelte`

## Testing Checklist

- [x] No TypeScript errors (`svelte-check`: 0 errors, 0 warnings)
- [x] Build completes successfully
- [x] Lint passes (Prettier + ESLint)
- [ ] All icons render correctly in browser
- [ ] Icons display correctly in production build