### PR TITLE
chore(deps): migrate svelte-sitemap from CLI to Vite plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint --ignore-pattern .svelte-kit/output .",
-		"postbuild": "svelte-sitemap --domain https://torrust.com/",
 		"update-contributors": "tsx scripts/updateContributors.ts",
 		"pre-commit": "bash scripts/pre-commit.sh",
 		"prepare": "git config core.hooksPath .githooks && chmod +x .githooks/pre-commit"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import { svelteSitemap } from 'svelte-sitemap/vite';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 import type { UserConfig } from 'vite';
@@ -9,6 +10,7 @@ const config: UserConfig = {
 	plugins: [
 		tailwindcss(),
 		sveltekit(),
+		svelteSitemap({ domain: 'https://torrust.com/' }),
 		ViteImagemin({
 			gifsicle: { optimizationLevel: 3 },
 			optipng: { optimizationLevel: 5 },


### PR DESCRIPTION
## Summary

Migrate svelte-sitemap from the deprecated CLI postbuild script to the recommended Vite plugin. This eliminates the deprecation warning on every build.

## Changes

- Add `svelteSitemap({ domain: 'https://torrust.com/' })` plugin to `vite.config.ts`
- Remove `postbuild` script from `package.json`

## Checklist

- [x] `npm run lint` passes
- [x] `npm run check` passes
- [x] `npm run build` succeeds — sitemap now generated via `Method: Vite plugin` (no deprecation warning)