### PR TITLE
chore: update Dependabot dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: package.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: package.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 				"@types/node": "^25.6.0",
 				"@types/prismjs": "^1.26.6",
 				"@typescript-eslint/eslint-plugin": "^8.61.1",
-				"@typescript-eslint/parser": "^8.58.2",
+				"@typescript-eslint/parser": "^8.61.1",
 				"eslint": "^10.2.0",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-prettier": "^5.5.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "torrust-website",
 			"version": "1.0.0",
 			"dependencies": {
-				"@fontsource-variable/roboto-mono": "^5.2.8",
+				"@fontsource-variable/roboto-mono": "^5.2.9",
 				"@fontsource-variable/roboto-slab": "^5.2.8",
 				"@iconify/svelte": "^5.2.1",
 				"@tailwindcss/container-queries": "^0.1.1",
@@ -58,6 +58,9 @@
 				"typescript-eslint": "^8.58.2",
 				"vite": "^8.0.8",
 				"vite-plugin-imagemin": "^0.6.1"
+			},
+			"engines": {
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@emnapi/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@iconify/svelte": "^5.2.1",
 				"@tailwindcss/container-queries": "^0.1.1",
 				"@tailwindcss/forms": "^0.5.11",
-				"@tailwindcss/typography": "^0.5.19",
+				"@tailwindcss/typography": "^0.5.20",
 				"@tailwindcss/vite": "^4.2.2",
 				"dateformat": "^5.0.3",
 				"flexsearch": "^0.8.212",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
 				"@typescript-eslint/parser": "^8.58.2",
 				"eslint": "^10.2.0",
 				"eslint-config-prettier": "^10.1.8",
-				"eslint-plugin-prettier": "^5.5.5",
+				"eslint-plugin-prettier": "^5.5.6",
 				"eslint-plugin-svelte": "^3.17.0",
 				"globals": "^17.5.0",
 				"mdsvex": "^0.12.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"@types/dateformat": "^5.0.3",
 				"@types/node": "^25.6.0",
 				"@types/prismjs": "^1.26.6",
-				"@typescript-eslint/eslint-plugin": "^8.58.2",
+				"@typescript-eslint/eslint-plugin": "^8.61.1",
 				"@typescript-eslint/parser": "^8.58.2",
 				"eslint": "^10.2.0",
 				"eslint-config-prettier": "^10.1.8",
@@ -55,7 +55,7 @@
 				"tailwindcss": "^4.2.2",
 				"tsx": "^4.21.0",
 				"typescript": "^6.0.2",
-				"typescript-eslint": "^8.58.2",
+				"typescript-eslint": "^8.61.1",
 				"vite": "^8.0.8",
 				"vite-plugin-imagemin": "^0.6.1"
 			},
@@ -2255,17 +2255,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
-			"integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+			"integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.61.0",
-				"@typescript-eslint/type-utils": "8.61.0",
-				"@typescript-eslint/utils": "8.61.0",
-				"@typescript-eslint/visitor-keys": "8.61.0",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/type-utils": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -2278,22 +2278,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.61.0",
+				"@typescript-eslint/parser": "^8.61.1",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
-			"integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+			"integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.61.0",
-				"@typescript-eslint/types": "8.61.0",
-				"@typescript-eslint/typescript-estree": "8.61.0",
-				"@typescript-eslint/visitor-keys": "8.61.0",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2309,14 +2309,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-			"integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+			"integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.61.0",
-				"@typescript-eslint/types": "^8.61.0",
+				"@typescript-eslint/tsconfig-utils": "^8.61.1",
+				"@typescript-eslint/types": "^8.61.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2331,14 +2331,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
-			"integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+			"integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.61.0",
-				"@typescript-eslint/visitor-keys": "8.61.0"
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2349,9 +2349,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-			"integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+			"integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2366,15 +2366,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
-			"integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+			"integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.61.0",
-				"@typescript-eslint/typescript-estree": "8.61.0",
-				"@typescript-eslint/utils": "8.61.0",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -2391,9 +2391,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-			"integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
@@ -2405,16 +2405,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-			"integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+			"integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.61.0",
-				"@typescript-eslint/tsconfig-utils": "8.61.0",
-				"@typescript-eslint/types": "8.61.0",
-				"@typescript-eslint/visitor-keys": "8.61.0",
+				"@typescript-eslint/project-service": "8.61.1",
+				"@typescript-eslint/tsconfig-utils": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -2433,16 +2433,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
-			"integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+			"integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.61.0",
-				"@typescript-eslint/types": "8.61.0",
-				"@typescript-eslint/typescript-estree": "8.61.0"
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2457,13 +2457,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-			"integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+			"integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/types": "8.61.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -10791,16 +10791,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
-			"integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+			"integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.61.0",
-				"@typescript-eslint/parser": "8.61.0",
-				"@typescript-eslint/typescript-estree": "8.61.0",
-				"@typescript-eslint/utils": "8.61.0"
+				"@typescript-eslint/eslint-plugin": "8.61.1",
+				"@typescript-eslint/parser": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"@types/node": "^25.6.0",
 		"@types/prismjs": "^1.26.6",
 		"@typescript-eslint/eslint-plugin": "^8.61.1",
-		"@typescript-eslint/parser": "^8.58.2",
+		"@typescript-eslint/parser": "^8.61.1",
 		"eslint": "^10.2.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-prettier": "^5.5.6",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"@iconify/svelte": "^5.2.1",
 		"@tailwindcss/container-queries": "^0.1.1",
 		"@tailwindcss/forms": "^0.5.11",
-		"@tailwindcss/typography": "^0.5.19",
+		"@tailwindcss/typography": "^0.5.20",
 		"@tailwindcss/vite": "^4.2.2",
 		"dateformat": "^5.0.3",
 		"flexsearch": "^0.8.212",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"vite-plugin-imagemin": "^0.6.1"
 	},
 	"dependencies": {
-		"@fontsource-variable/roboto-mono": "^5.2.8",
+		"@fontsource-variable/roboto-mono": "^5.2.9",
 		"@fontsource-variable/roboto-slab": "^5.2.8",
 		"@iconify/svelte": "^5.2.1",
 		"@tailwindcss/container-queries": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@types/dateformat": "^5.0.3",
 		"@types/node": "^25.6.0",
 		"@types/prismjs": "^1.26.6",
-		"@typescript-eslint/eslint-plugin": "^8.58.2",
+		"@typescript-eslint/eslint-plugin": "^8.61.1",
 		"@typescript-eslint/parser": "^8.58.2",
 		"eslint": "^10.2.0",
 		"eslint-config-prettier": "^10.1.8",
@@ -51,7 +51,7 @@
 		"tailwindcss": "^4.2.2",
 		"tsx": "^4.21.0",
 		"typescript": "^6.0.2",
-		"typescript-eslint": "^8.58.2",
+		"typescript-eslint": "^8.61.1",
 		"vite": "^8.0.8",
 		"vite-plugin-imagemin": "^0.6.1"
 	},

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@typescript-eslint/parser": "^8.58.2",
 		"eslint": "^10.2.0",
 		"eslint-config-prettier": "^10.1.8",
-		"eslint-plugin-prettier": "^5.5.5",
+		"eslint-plugin-prettier": "^5.5.6",
 		"eslint-plugin-svelte": "^3.17.0",
 		"globals": "^17.5.0",
 		"mdsvex": "^0.12.7",


### PR DESCRIPTION
## Summary

Update all open Dependabot dependency bumps in a single PR, with each update committed separately.

## Changes

- **deps:** bump `@fontsource-variable/roboto-mono` from ^5.2.8 to ^5.2.9
- **deps:** bump `@tailwindcss/typography` from ^0.5.19 to ^0.5.20
- **deps-dev:** bump `eslint-plugin-prettier` from ^5.5.5 to ^5.5.6
- **deps-dev:** bump `typescript-eslint` and `@typescript-eslint/eslint-plugin` to ^8.61.1
- **deps:** bump `actions/setup-node` from v4 to v6 in CI workflows

Closes #212
Closes #211
Closes #210
Closes #205
Closes #203
Closes #202
