### PR TITLE
feat(seo): add Open Graph meta tags for blog post social previews

### DIFF
--- a/src/lib/components/organisms/Post.svelte
+++ b/src/lib/components/organisms/Post.svelte
@@ -27,10 +27,24 @@
 	import Image from '$lib/components/atoms/Image.svelte';
 	import ShareButton from '$lib/components/singletons/ShareButton.svelte';
 	import Tag from '$lib/components/atoms/Tag.svelte';
+	import { siteBaseUrl } from '$lib/data/meta';
 </script>
 
 <svelte:head>
 	<title>{title}</title>
+	<meta property="og:title" content={title} />
+	<meta name="twitter:title" content={title} />
+
+	<meta name="description" content={excerpt} />
+	<meta property="og:description" content={excerpt} />
+	<meta name="twitter:description" content={excerpt} />
+
+	<meta property="og:image" content={`${siteBaseUrl}${coverImage}`} />
+	<meta name="twitter:image" content={`${siteBaseUrl}${coverImage}`} />
+
+	<meta property="og:url" content={`${siteBaseUrl}/blog/${slug}`} />
+	<meta property="og:type" content="article" />
+	<meta name="twitter:card" content="summary_large_image" />
 </svelte:head>
 
 <div class="container">


### PR DESCRIPTION
## Summary

Add Open Graph and Twitter Card meta tags to blog post pages so that social platforms (WhatsApp, Telegram, Discord, etc.) show a rich preview with title, description, and cover image when sharing.

## Changes

- Added `og:title`, `og:description`, `og:image`, `og:url`, `og:type` meta tags to `Post.svelte`
- Added `twitter:title`, `twitter:description`, `twitter:image`, `twitter:card` meta tags to `Post.svelte`
- Imported `siteBaseUrl` from `$lib/data/meta` to build absolute image and URL paths

## Related issue

Closes #183

## Checklist

- [x] `npm run lint` passes
- [x] `npm run check` passes
- [ ] Manually tested in the browser (if UI changes)
