### PR TITLE
fix: update UNIT3D article - demo server has been shut down

### DIFF
--- a/src/routes/blog/review-and-setup-guide-for-unit3d/+page.svelte
+++ b/src/routes/blog/review-and-setup-guide-for-unit3d/+page.svelte
@@ -77,8 +77,8 @@
 
 				<Callout type="warning">
 					<s
-						>To write this post we have setup a new demo site on: <a
-							href="https://www.unit3d-demo.com/">https://www.unit3d-demo.com</a
+						>To write this post we have setup a new demo site on: <code
+							>https://www.unit3d-demo.com</code
 						>. Following the tutorial section you can also easily deploy your UNIT3D Index. The demo
 						site could be shutdown at any time.</s
 					>
@@ -250,8 +250,8 @@
 				<h4 id="external-services">External Services</h4>
 				<ul>
 					<li>
-						Domain: We registered a new one only for this purpose (now shut down): <a
-							href="https://unit3d-demo.com/">https://unit3d-demo.com/</a
+						Domain: We registered a new one only for this purpose (now shut down): <code
+							>https://unit3d-demo.com</code
 						>.
 					</li>
 					<li>
@@ -348,7 +348,7 @@
 					code={`ping your-domain.com
 PING your-domain.com (your-server-ip) 56(84) bytes of data.\n
 ping www.your-domain.com
-PING your-domain.com (your-server-ip) 56(84) bytes of data.`}
+PING www.your-domain.com (your-server-ip) 56(84) bytes of data.`}
 				/>
 
 				<p>Also, check that you can login using SSH:</p>
@@ -420,9 +420,8 @@ sudo ./install.sh`}
 
 				<Callout type="warning">
 					<s
-						>If the official demo is down you can apply for signing up in our demo on: <a
-							href="https://www.unit3d-demo.com/application"
-							>https://www.unit3d-demo.com/application</a
+						>If the official demo is down you can apply for signing up in our demo on: <code
+							>https://www.unit3d-demo.com/application</code
 						>. You don't need to provide real data, just a valid email so we can confirm it
 						manually. We want to highlight, however, that we may shut down this demo at any time.</s
 					>

--- a/src/routes/blog/review-and-setup-guide-for-unit3d/+page.svelte
+++ b/src/routes/blog/review-and-setup-guide-for-unit3d/+page.svelte
@@ -66,7 +66,7 @@
 					</li>
 					<li>
 						<strong>Official Demo Site:</strong>
-						<a href="https://unit3d.dev/">https://unit3d.dev/</a> (currently not working).
+						<a href="https://unit3d.dev/">https://unit3d.dev/</a>.
 					</li>
 				</ul>
 				<p>
@@ -75,11 +75,15 @@
 					>.
 				</p>
 
-				<Callout type="info">
-					To write this post we have setup a new demo site on: <a
-						href="https://www.unit3d-demo.com/">https://www.unit3d-demo.com</a
-					>. Following the tutorial section you can also easily deploy your UNIT3D Index. The demo
-					site could be shutdown at any time.
+				<Callout type="warning">
+					<s
+						>To write this post we have setup a new demo site on: <a
+							href="https://www.unit3d-demo.com/">https://www.unit3d-demo.com</a
+						>. Following the tutorial section you can also easily deploy your UNIT3D Index. The demo
+						site could be shutdown at any time.</s
+					>
+					<br />
+					<strong>Update:</strong> The demo site has been shut down.
 				</Callout>
 
 				<h3 id="overview">Overview</h3>
@@ -246,7 +250,7 @@
 				<h4 id="external-services">External Services</h4>
 				<ul>
 					<li>
-						Domain: We registered a new one only for this purpose: <a
+						Domain: We registered a new one only for this purpose (now shut down): <a
 							href="https://unit3d-demo.com/">https://unit3d-demo.com/</a
 						>.
 					</li>
@@ -341,15 +345,15 @@
 
 				<CodeBlock
 					lang="console"
-					code={`ping unit3d-demo.com
-PING unit3d-demo.com (134.122.65.71) 56(84) bytes of data.\n
-ping <www.unit3d-demo.com>
-PING unit3d-demo.com (134.122.65.71) 56(84) bytes of data.`}
+					code={`ping your-domain.com
+PING your-domain.com (your-server-ip) 56(84) bytes of data.\n
+ping www.your-domain.com
+PING your-domain.com (your-server-ip) 56(84) bytes of data.`}
 				/>
 
 				<p>Also, check that you can login using SSH:</p>
 
-				<CodeBlock lang="console" code={`ssh root@134.122.65.71`} />
+				<CodeBlock lang="console" code={`ssh root@your-server-ip`} />
 
 				<h3 id="step-2-update-the-server">Step 2. Update the Server</h3>
 				<p>This is only a recommendation before running the installer.</p>
@@ -414,12 +418,16 @@ sudo ./install.sh`}
 
 				<p>You can use the owner account credentials you provided during the installation.</p>
 
-				<Callout type="info">
-					If the official demo is down you can apply for signing up in our demo on: <a
-						href="https://www.unit3d-demo.com/application"
-						>https://www.unit3d-demo.com/application</a
-					>. You don't need to provide real data, just a valid email so we can confirm it manually.
-					We want to highlight, however, that we may shut down this demo at any time.
+				<Callout type="warning">
+					<s
+						>If the official demo is down you can apply for signing up in our demo on: <a
+							href="https://www.unit3d-demo.com/application"
+							>https://www.unit3d-demo.com/application</a
+						>. You don't need to provide real data, just a valid email so we can confirm it
+						manually. We want to highlight, however, that we may shut down this demo at any time.</s
+					>
+					<br />
+					<strong>Update:</strong> The demo site has been shut down.
 				</Callout>
 
 				<h3 id="troubleshooting">Troubleshooting</h3>

--- a/src/routes/blog/review-and-setup-guide-for-unit3d/metadata.ts
+++ b/src/routes/blog/review-and-setup-guide-for-unit3d/metadata.ts
@@ -3,9 +3,9 @@ export const metadata = {
 	slug: 'review-and-setup-guide-for-unit3d',
 	contributor: 'Jose Celano',
 	contributorSlug: 'jose-celano',
-	date: '2024-08-16T09:36:17.990Z',
+	date: '2026-06-19T09:00:00.000Z',
 	coverImage: '/images/posts/review-and-setup-guide-for-unit3d/unit3d-user-profile-screenshot.png',
 	excerpt:
-		"UNIT3D is one of the fully featured BitTorrent Indexes that promises a robust, customizable, and community-driven experience. In this first post of our review series at Torrust, we’ll dive into UNIT3D, evaluating its features, installation process, and overall usability. Whether you're an open-source advocate or a BitTorrent expert, this guide will help you understand the ins and outs of UNIT3D, including a step-by-step tutorial to set it up on a Digital Ocean droplet.",
+		"UNIT3D is one of the fully featured BitTorrent Indexes that promises a robust, customizable, and community-driven experience. In this first post of our review series at Torrust, we’ll dive into UNIT3D, evaluating its features, installation process, and overall usability. Whether you're an open-source advocate or a BitTorrent expert, this guide will help you understand the ins and outs of UNIT3D, including a step-by-step tutorial to set it up on a Digital Ocean droplet. Note: the demo site we had set up for this article has been shut down.",
 	tags: ['Tutorial', 'Review', 'Index', 'Third-party']
 };


### PR DESCRIPTION
Closes #156

The `unit3d-demo.com` demo server mentioned in the UNIT3D review article has been shut down. This PR updates the article to reflect that:

- Both callouts that referenced the active demo now have the original text struck through with an **Update:** note indicating the demo has been shut down
- The "Official Demo Site" bullet no longer says "(currently not working)" — stale info
- Ping/SSH examples in the tutorial use generic placeholders instead of the specific shut-down domain/IP
- Updated metadata date and excerpt